### PR TITLE
feat: section-level indexing and deep chunking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,8 @@ Using bash with yq:
 - **Embedded corpora**: Documentation repos can contain their own corpus at `.hiivmind/corpus/`, powered by `type: self` sources — see spec at `docs/superpowers/specs/2026-03-25-embedded-corpus-design.md`
 - **Cross-corpus bridges**: Projects with 2+ registered corpora can create concept bridges in `registry-graph.yaml`, with query-routing aliases — see spec at `docs/superpowers/specs/2026-03-26-graph-editing-and-bridge-design.md`
 - **Optional embeddings**: Entry-level semantic embeddings (`index-embeddings.lance/`) via fastembed enhance retrieval for large/tiered corpora. Entries include `concepts[]` field for zettelkasten-enriched embedding text. Cross-corpus routing searches per-corpus embeddings directly. Opt-in during build with heuristic-based advice. Graceful fallback to keyword/LLM approach when fastembed unavailable — see specs at `docs/superpowers/specs/2026-03-27-rag-embeddings-design.md`, `docs/superpowers/specs/2026-03-27-lancedb-revision-design.md`, and `docs/superpowers/specs/2026-03-27-corpus-consolidation-design.md`
+- **Section-level indexing**: Sources with `sections.enabled: true` generate sub-entries for heading-bounded sections with their own metadata embeddings. Extends the existing metadata-embedding pattern to finer granularity — see spec at `docs/superpowers/specs/2026-04-05-section-indexing-and-deep-chunking-design.md`
+- **Deep chunking**: Sources with `chunking.enabled: true` split content into ~900-token chunks embedded into a separate `chunks-embeddings.lance/` file. Enables LanceDB native hybrid search (FTS + vector + RRF) for precise retrieval in unstructured content. Navigate skill fuses results across tiers with deduplication and query expansion.
 
 ## Index Format
 
@@ -293,6 +295,8 @@ These features span multiple skills and must stay synchronized:
 | Fork context (ADR-007) | navigate (template) | Frontmatter: context, agent, allowed-tools |
 | Embeddings | build, enhance, refresh, navigate, bridge, graph, discover, status | `index-embeddings.lance/` generation/query, fastembed detection, heuristic prompt, graph-boost, graceful fallback, cross-corpus routing via per-corpus embeddings |
 | Concept membership | build, graph, enhance, refresh, navigate | `concepts[]` field in index.yaml entries, bidirectional with graph.yaml concept definitions, enriches embedding text |
+| Section indexing | build, source-scanner, navigate, enhance, refresh | `sections:` config, `tier: section` entries, heading consistency detection, line_range in index.yaml |
+| Deep chunking | build, source-scanner, navigate, enhance, refresh | `chunking:` config, chunk.py invocation, `chunks-embeddings.lance/` generation/query, hybrid search, query expansion |
 
 ### When Adding New Features
 
@@ -330,6 +334,8 @@ refresh ──► index-embeddings.lance/ (incremental update, if model ready)
 bridge ──► queries per-corpus index-embeddings.lance/ (cross-corpus concept detection)
 navigate ◄── index-embeddings.lance/ (retrieval + cross-corpus routing)
 graph ◄── index-embeddings.lance/ (relationship candidate detection)
+build ──► chunks-embeddings.lance/ (optional, Phase 7b)
+navigate ◄── chunks-embeddings.lance/ (hybrid search + fusion)
 ```
 
 ### Reference Sections

--- a/agents/source-scanner.md
+++ b/agents/source-scanner.md
@@ -128,6 +128,94 @@ For each documentation file discovered during scanning, generate entry metadata:
 
 **Sampling strategy for entries:** For corpora with 50+ files, sample 5-10 representative files to establish tag/category conventions, then apply consistently across all files. For smaller corpora, analyze each file individually.
 
+### Section Entry Generation
+
+When the caller includes `sections_config:` in your input (sourced from the source's `sections:` block in config.yaml), generate section-level entries for qualifying headings.
+
+**When sections are enabled:**
+
+1. For each file, use the already-extracted `headings` list
+2. For each heading at `sections_config.min_level` or deeper:
+   a. Calculate content boundaries: from heading line to next heading of equal/higher level (or EOF)
+   b. Count non-blank content lines in that range
+   c. If content lines < `sections_config.min_content_lines`: skip
+   d. Read the section content (heading to boundary)
+   e. Generate: title (heading text), summary (1-2 sentences), tags, keywords
+   f. Construct section entry with: `parent`, `tier: section`, `anchor`, `heading_level`, `line_range`
+3. Append section entries to the `entries:` list in your output, after the parent file entry
+
+**Section entry output format** (appended to entries list):
+
+```yaml
+entries:
+  # ... file entry ...
+  - path: "expressions.md"
+    parent: "polars:expressions.md"
+    tier: section
+    anchor: "window-functions"
+    title: "Window Functions"
+    summary: "How to use over() for window expressions"
+    tags: [window, aggregation]
+    keywords: [partition_by, over]
+    concepts: []
+    category: reference
+    content_type: markdown
+    heading_level: 2
+    line_range: [145, 210]
+    size: standard
+    stale: false
+```
+
+**Heading consistency assessment:**
+
+During file sampling (step 4), assess heading consistency across the source:
+
+```yaml
+heading_consistency: high    # >80% of files have consistent h2+ structure
+heading_consistency_note: "Consistent h2 sections in 95% of files"
+```
+
+Report this in the top-level scan output so the build skill can make informed recommendations.
+
+### Chunk Generation
+
+When the caller includes `chunking_config:` in your input (sourced from the source's `chunking:` block in config.yaml), generate chunks for each file.
+
+**When chunking is enabled:**
+
+1. For each documentation file in the source:
+   a. Run: `python3 ${CLAUDE_PLUGIN_ROOT}/lib/corpus/scripts/chunk.py "{file_path}" --strategy {chunking_config.strategy} --target-tokens {chunking_config.target_tokens} --overlap-tokens {chunking_config.overlap_tokens} --json`
+   b. Parse the JSON output
+   c. For each chunk, annotate with corpus-level IDs:
+      - `id`: `{source_id}:{relative_path}#chunk-{chunk_index}`
+      - `parent`: `{source_id}:{relative_path}`
+      - `source`: `{source_id}`
+      - `path`: `{relative_path}`
+2. Append all annotated chunks to a `chunks:` block in your output
+
+**Chunk output format** (separate from entries, appended to scan report):
+
+```yaml
+chunks:
+  - id: "notes:2026-03-15-standup.md#chunk-0"
+    parent: "notes:2026-03-15-standup.md"
+    source: "notes"
+    path: "2026-03-15-standup.md"
+    chunk_index: 0
+    chunk_text: "Discussion about Q3 timeline and resource allocation..."
+    line_range: [1, 25]
+    overlap_prev: false
+  - id: "notes:2026-03-15-standup.md#chunk-1"
+    parent: "notes:2026-03-15-standup.md"
+    source: "notes"
+    path: "2026-03-15-standup.md"
+    chunk_index: 1
+    chunk_text: "Bob raised concerns about infrastructure costs..."
+    line_range: [20, 45]
+    overlap_prev: true
+chunk_count: 2
+```
+
 ## Extraction
 
 When the caller includes `extraction_config:` in your input (sourced from the source's `extraction:` block in config.yaml), run the extraction pipeline after scanning and append an `extraction:` block to your YAML output.

--- a/lib/corpus/patterns/chunking.md
+++ b/lib/corpus/patterns/chunking.md
@@ -1,0 +1,128 @@
+# Pattern: Deep Chunking
+
+## Purpose
+
+Deep chunking splits documents into ~900-token content chunks and embeds the actual
+text (not metadata summaries) into a separate `chunks-embeddings.lance/` file. This
+enables LanceDB native hybrid search (FTS + vector + RRF) for precise retrieval in
+unstructured content where file-level or section-level indexing is too coarse.
+
+## When to Use
+
+Recommended for:
+- Meeting transcripts (no heading structure, buried insights)
+- Diary notes, journal entries
+- Blog posts, articles
+- Obsidian vaults with long unstructured notes
+- Any content where relevant information could be anywhere in a file
+
+Not the right tool for:
+- Well-structured reference documentation (use section indexing instead)
+- Small files that fit in a single context window
+
+## Source Configuration
+
+```yaml
+sources:
+  - id: meeting-notes
+    type: local
+    path: ~/notes/meetings/
+    chunking:
+      enabled: true
+      strategy: transcript
+      target_tokens: 900      # optional, strategy default used if omitted
+      overlap_tokens: 100     # optional, strategy default used if omitted
+```
+
+### Strategies
+
+| Strategy | Best For | Boundary Scoring | Default Target | Default Overlap |
+|----------|---------|-----------------|----------------|-----------------|
+| `markdown` | Markdown docs with headings | Headings (100), blank lines (20), list items (10) | 900 | 100 |
+| `transcript` | Meeting notes, conversations | Speaker turns (80), timestamps (50), blank lines (20) | 900 | 100 |
+| `code` | Source code files | Function/class boundaries (100), blank lines (20) | 600 | 50 |
+| `paragraph` | Plain text, prose | Double newlines (50), single newlines (10) | 900 | 100 |
+
+## Chunk Generation
+
+### CLI
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/lib/corpus/scripts/chunk.py <file> \
+  --strategy <strategy> \
+  --target-tokens <n> \
+  --overlap-tokens <n> \
+  --json
+```
+
+Output: JSON array of chunks with `text`, `line_range`, `chunk_index`, `overlap_prev`.
+
+### Build Integration
+
+During build Phase 5d, for each source with `chunking.enabled: true`:
+
+1. Source-scanner runs chunk.py on each file
+2. Annotates each chunk with `id`, `parent`, `source`, `path` fields
+3. Aggregates all chunks into a single JSON file
+4. embed.py `--mode chunks` embeds into `chunks-embeddings.lance/`
+
+### Chunk ID Format
+
+`{source_id}:{path}#chunk-{n}` — e.g., `notes:2026-03-15-standup.md#chunk-3`
+
+## Embedding
+
+Chunks embed the actual `chunk_text` content — NOT metadata summaries. This is the
+key difference from file/section-level embeddings.
+
+No `passage:` prefix is used for chunk embeddings (raw content embedding).
+
+### Lance Schema
+
+Table name: `chunks` (in `chunks-embeddings.lance/`)
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | string | `{source_id}:{path}#chunk-{n}` |
+| `parent` | string | `{source_id}:{path}` — parent file ID |
+| `source` | string | Source ID |
+| `path` | string | Relative file path |
+| `chunk_index` | int | Sequential within parent |
+| `chunk_text` | string | Actual content (embedded AND FTS-indexed) |
+| `vector` | vector[384] | Content embedding |
+| `line_range` | int[2] | [start, end] lines in source file |
+| `overlap_prev` | bool | Whether this chunk overlaps with previous |
+| `updated_at` | string | ISO-8601 timestamp |
+
+### Indexes
+
+- FTS index on `chunk_text` — enables LanceDB hybrid search
+- Vector index (IVF_PQ) if chunk count > 500
+
+## Hybrid Search
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/lib/corpus/scripts/search.py chunks-embeddings.lance/ "query" \
+  --table chunks --hybrid --text-column chunk_text --top-k 15 --json
+```
+
+This uses LanceDB native hybrid search: FTS on `chunk_text` + vector similarity + RRF fusion.
+
+## Query Expansion
+
+When `chunks-embeddings.lance/` exists, the navigate skill generates 2 variant queries:
+- Lexical variant (keyword reformulation)
+- Conceptual variant (synonym/concept expansion)
+
+Original query is weighted 2x. Only applied to chunk search, not metadata search.
+
+## Distribution
+
+`chunks-embeddings.lance/` is committed to the corpus repo alongside `index-embeddings.lance/`.
+Larger (10-100MB) since it stores actual text. Only present when at least one source has chunking enabled.
+
+## Related Patterns
+
+- [section-indexing.md](section-indexing.md) — Section-level indexing (complementary)
+- [embeddings.md](embeddings.md) — Embedding pipeline and LanceDB patterns
+- [index-format-v2.md](index-format-v2.md) — Index schema

--- a/lib/corpus/patterns/embeddings.md
+++ b/lib/corpus/patterns/embeddings.md
@@ -95,6 +95,26 @@ Stored alongside index.yaml in the corpus root. **MUST be committed to the repo*
 distributable artifact, not a cache. Consumers get pre-computed embeddings without needing
 fastembed installed. Do NOT add to .gitignore. Treat it the same as index.yaml and index.md.
 
+### Per-corpus: chunks-embeddings.lance/
+
+Generate content embeddings from chunked documents:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/lib/corpus/scripts/embed.py --mode chunks chunks.json chunks-embeddings.lance/
+```
+
+Separate from `index-embeddings.lance/`. Contains actual document content (not metadata
+summaries). Enables LanceDB native hybrid search (FTS + vector + RRF).
+
+**Schema:** See `${CLAUDE_PLUGIN_ROOT}/lib/corpus/patterns/chunking.md`
+
+**Key differences from index-embeddings:**
+- Table name: `chunks` (not `embeddings`)
+- Embeds raw text (no `passage:` prefix)
+- FTS index on `chunk_text` column enables hybrid search
+- Searched with `--table chunks --hybrid --text-column chunk_text`
+- Larger size (10-100MB) since content is stored in table
+
 ### Cross-corpus routing
 
 Cross-corpus routing does not require a separate embedding dataset. Navigate Phase 2
@@ -122,6 +142,14 @@ at `.hiivmind/corpus/cache/{corpus_id}/`.
 
 See navigate skill § Remote Embedding Cache for the full freshness check algorithm
 and sparse clone procedure.
+
+### Remote chunk embedding cache
+
+Same mechanism as index-embeddings cache. Both Lance directories are sparse-cloned
+together. `_cache_meta.json` covers both — a single SHA check validates freshness for
+the entire corpus.
+
+Cache location: `.hiivmind/corpus/cache/{corpus_id}/chunks-embeddings.lance/`
 
 ### Incremental updates
 
@@ -198,6 +226,25 @@ python3 search.py index-embeddings.lance/ "how to speed up queries" --top-k 15 -
 
 This replaces the need for a separate BM25 keyword index. Exact-match needs (API names,
 config keys, version strings) are handled by SQL predicates on text columns.
+
+### Native Hybrid Search (chunks)
+
+For chunk datasets, use LanceDB native hybrid search instead of vector + SQL:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/lib/corpus/scripts/search.py chunks-embeddings.lance/ "query" \
+  --table chunks --hybrid --text-column chunk_text --top-k 15 --json
+```
+
+This runs vector similarity AND full-text search on `chunk_text` simultaneously,
+then fuses results with Reciprocal Rank Fusion (RRF). Equivalent to BM25 + vector
+search without a separate BM25 index.
+
+**When to use native hybrid vs vector + SQL:**
+- **Native hybrid (`--hybrid`):** For chunk content where both lexical and semantic
+  matching matter. Default for chunk searches.
+- **Vector + SQL (`--where`):** For metadata embeddings where exact tag/keyword matches
+  supplement semantic search. Default for index-embeddings searches.
 
 ## Staleness Detection
 

--- a/lib/corpus/patterns/index-format-v2.md
+++ b/lib/corpus/patterns/index-format-v2.md
@@ -91,6 +91,84 @@ meta:
 | `stale_since` | datetime | no | When the entry was marked stale. Null if not stale |
 | `last_indexed` | datetime | yes | When this entry was last scanned by the source-scanner agent |
 
+## Section Entries (Tier 2)
+
+When a source has `sections.enabled: true`, the source-scanner generates sub-entries
+for heading-bounded sections within large or structured documents. Section entries
+live in the same `entries` list as file-level entries.
+
+### Additional Fields for Section Entries
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `parent` | string | yes (sections) | ID of the parent file entry |
+| `tier` | enum | yes (sections) | Always `section` for section entries. File entries omit this field or use `file` |
+| `anchor` | string | yes (sections) | Slugified heading text (URL fragment) |
+| `heading_level` | integer | yes (sections) | Heading level (2-6). Level 1 is typically the page title |
+| `line_range` | integer[2] | yes (sections) | `[start_line, end_line]` — 1-indexed, inclusive |
+
+### Section Entry ID Format
+
+`{parent_id}#{anchor}` — e.g., `polars:expressions.md#window-functions`
+
+### Example
+
+```yaml
+entries:
+  # File-level entry (unchanged)
+  - id: "polars:expressions.md"
+    source: polars
+    path: "expressions.md"
+    title: "Expressions"
+    summary: "Overview of Polars expression system"
+    tags: [expressions, core]
+    keywords: [col, lit, when, then]
+    concepts: [expressions]
+    category: reference
+    content_type: markdown
+    size: large
+    grep_hint: "grep -n '^## ' FILE"
+    headings:
+      - anchor: "window-functions"
+        title: "Window Functions"
+      - anchor: "aggregations"
+        title: "Aggregations"
+    links_to: []
+    links_from: []
+    frontmatter: {}
+    stale: false
+    stale_since: null
+    last_indexed: "2026-04-05T10:00:00Z"
+
+  # Section entry (new)
+  - id: "polars:expressions.md#window-functions"
+    parent: "polars:expressions.md"
+    tier: section
+    source: polars
+    path: "expressions.md"
+    anchor: "window-functions"
+    title: "Window Functions"
+    summary: "How to use over() for window expressions in Polars"
+    tags: [window, aggregation, over]
+    keywords: [partition_by, order_by, rolling]
+    concepts: ["window-expressions"]
+    category: reference
+    content_type: markdown
+    heading_level: 2
+    line_range: [145, 210]
+    stale: false
+    stale_since: null
+    last_indexed: "2026-04-05T10:00:00Z"
+```
+
+### Embedding
+
+Section entries use the same metadata-embedding pattern as file entries:
+`"passage: {title} | {summary} | {', '.join(tags)} | {', '.join(concepts)}"`
+
+They are embedded into the existing `index-embeddings.lance/` alongside file entries.
+The `tier` field in index.yaml (not in Lance) lets the navigate skill distinguish them.
+
 ## Meta Section
 
 | Field | Type | Description |

--- a/lib/corpus/patterns/section-indexing.md
+++ b/lib/corpus/patterns/section-indexing.md
@@ -1,0 +1,89 @@
+# Pattern: Section-Level Indexing
+
+## Purpose
+
+Section-level indexing promotes heading-bounded sections within large structured
+documents into first-class index entries with their own metadata and embeddings.
+This enables retrieval at the section level instead of requiring the LLM to navigate
+entire large files.
+
+## When to Use
+
+Recommended when a source has:
+- Files exceeding 1000 lines (already flagged as `size: large`)
+- Consistent heading structure (h2+ headings present and meaningful)
+- Structured documentation (reference, guides, tutorials)
+
+Not recommended for:
+- Unstructured content (meeting transcripts, diary notes) — use deep chunking instead
+- Files with inconsistent or missing headings
+
+## Source Configuration
+
+```yaml
+sources:
+  - id: polars-docs
+    type: git
+    repo: pola-rs/polars
+    docs_root: docs/
+    sections:
+      enabled: true
+      min_level: 2         # Only h2+ become entries (default: 2)
+      min_content_lines: 5 # Skip trivially short sections (default: 5)
+```
+
+### Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `enabled` | false | Enable section-level indexing for this source |
+| `min_level` | 2 | Minimum heading level to promote (1=h1, 2=h2, etc.) |
+| `min_content_lines` | 5 | Minimum lines of content under a heading to create an entry |
+
+## Source-Scanner Behavior
+
+When `sections.enabled: true` is present in the source config passed to the
+source-scanner, the scanner generates additional section entries for each
+qualifying heading in each file.
+
+### Section entry generation
+
+For each file with headings:
+
+1. Parse heading structure (already extracted for the `headings` field)
+2. For each heading at `min_level` or deeper:
+   a. Calculate content boundaries: from this heading to the next heading of equal or higher level (or end of file)
+   b. Count content lines (excluding blank lines)
+   c. If content lines < `min_content_lines`: skip
+   d. Generate metadata: title (heading text), summary, tags, keywords
+   e. Set `line_range` to `[heading_line, last_content_line]`
+   f. Set `anchor` to slugified heading text
+   g. Set `parent` to the file entry ID
+   h. Set `tier: section`
+
+### Heading consistency detection
+
+The source-scanner should assess heading consistency during the initial file
+sampling phase (step 4 in its process). Report in the scan output:
+
+```yaml
+heading_consistency: high|mixed|low
+heading_consistency_note: "Consistent h2 sections across 90% of files"
+```
+
+This informs the build skill's indexing depth recommendation.
+
+## Relationship to Deep Chunking
+
+Section indexing and deep chunking are independent. A source can have both:
+- Sections capture the semantic structure (meaningful headings with summaries)
+- Chunks capture content for retrieval (FTS + vector search on actual text)
+
+For sources with both enabled, section entries go into `index-embeddings.lance/`
+(metadata embeddings) and chunks go into `chunks-embeddings.lance/` (content embeddings).
+
+## Related Patterns
+
+- [index-format-v2.md](index-format-v2.md) — Full schema including section fields
+- [embeddings.md](embeddings.md) — Embedding pipeline (section entries use existing pipeline)
+- [chunking.md](chunking.md) — Deep chunking (complementary feature)

--- a/lib/corpus/scripts/chunk.py
+++ b/lib/corpus/scripts/chunk.py
@@ -96,6 +96,7 @@ def score_line(line: str, strategy: str) -> int:
     elif strategy == "paragraph":
         if line.strip() == "":
             return scores["double_newline"]
+        return scores["single_newline"]
 
     return 0
 
@@ -274,6 +275,9 @@ if __name__ == "__main__":
         main()
     except SystemExit:
         raise
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(3)

--- a/lib/corpus/scripts/chunk.py
+++ b/lib/corpus/scripts/chunk.py
@@ -211,7 +211,7 @@ def chunk_text(
                     break
             chunk_start = max(chunk_start + 1, split_at - overlap_lines)
         else:
-            chunk_start = split_at
+            chunk_start = max(chunk_start + 1, split_at)
 
     return chunks
 

--- a/lib/corpus/scripts/chunk.py
+++ b/lib/corpus/scripts/chunk.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Deterministic document chunking with strategy-based boundary detection.
+
+Usage:
+  python3 chunk.py <file> --strategy <markdown|transcript|code|paragraph> [--target-tokens 900] [--overlap-tokens 100] [--json]
+
+Splits a document into chunks using boundary scoring. Each strategy assigns
+scores to potential break points (headings, blank lines, speaker turns, etc.)
+and picks the highest-scoring boundary within a window of the target size.
+
+Output: JSON array of chunks with text, line_range, chunk_index, overlap_prev.
+
+Exit codes:
+  0 - success
+  1 - invalid strategy
+  2 - file not found
+  3 - other error
+"""
+import argparse
+import json
+import math
+import re
+import sys
+from pathlib import Path
+
+TOKENS_PER_WORD = 1.3
+
+BOUNDARY_SCORES = {
+    "markdown": {
+        "heading": 100,
+        "blank_line": 20,
+        "list_item": 10,
+    },
+    "transcript": {
+        "speaker_turn": 80,
+        "timestamp": 50,
+        "blank_line": 20,
+    },
+    "code": {
+        "function_boundary": 100,
+        "blank_line": 20,
+    },
+    "paragraph": {
+        "double_newline": 50,
+        "single_newline": 10,
+    },
+}
+
+STRATEGY_DEFAULTS = {
+    "markdown": {"target_tokens": 900, "overlap_tokens": 100},
+    "transcript": {"target_tokens": 900, "overlap_tokens": 100},
+    "code": {"target_tokens": 600, "overlap_tokens": 50},
+    "paragraph": {"target_tokens": 900, "overlap_tokens": 100},
+}
+
+HEADING_RE = re.compile(r"^#{1,6}\s+")
+SPEAKER_RE = re.compile(r"^[A-Z][a-zA-Z\s]*:\s")
+TIMESTAMP_RE = re.compile(r"^\[?\d{1,2}:\d{2}(:\d{2})?\]?\s")
+LIST_ITEM_RE = re.compile(r"^[\s]*[-*+]\s|^[\s]*\d+\.\s")
+CODE_BOUNDARY_RE = re.compile(
+    r"^(def |class |function |fn |func |pub fn |async fn |export |const \w+ = |let \w+ = )"
+)
+
+
+def estimate_tokens(text: str) -> int:
+    """Estimate token count from text."""
+    return max(1, math.ceil(len(text.split()) * TOKENS_PER_WORD))
+
+
+def score_line(line: str, strategy: str) -> int:
+    """Score a line as a potential chunk boundary."""
+    scores = BOUNDARY_SCORES[strategy]
+
+    if strategy == "markdown":
+        if HEADING_RE.match(line):
+            return scores["heading"]
+        if line.strip() == "":
+            return scores["blank_line"]
+        if LIST_ITEM_RE.match(line):
+            return scores["list_item"]
+
+    elif strategy == "transcript":
+        if SPEAKER_RE.match(line):
+            return scores["speaker_turn"]
+        if TIMESTAMP_RE.match(line):
+            return scores["timestamp"]
+        if line.strip() == "":
+            return scores["blank_line"]
+
+    elif strategy == "code":
+        if CODE_BOUNDARY_RE.match(line):
+            return scores["function_boundary"]
+        if line.strip() == "":
+            return scores["blank_line"]
+
+    elif strategy == "paragraph":
+        if line.strip() == "":
+            return scores["double_newline"]
+
+    return 0
+
+
+def chunk_text(
+    text: str,
+    strategy: str = "markdown",
+    target_tokens: int | None = None,
+    overlap_tokens: int | None = None,
+) -> list[dict]:
+    """Split text into chunks using boundary scoring.
+
+    Returns list of dicts with: text, line_range, chunk_index, overlap_prev.
+    Line ranges are 1-indexed.
+    """
+    if not text or not text.strip():
+        return []
+
+    if strategy not in BOUNDARY_SCORES:
+        raise ValueError(f"Unknown strategy: {strategy}")
+
+    defaults = STRATEGY_DEFAULTS[strategy]
+    if target_tokens is None:
+        target_tokens = defaults["target_tokens"]
+    if overlap_tokens is None:
+        overlap_tokens = defaults["overlap_tokens"]
+
+    lines = text.split("\n")
+    total_lines = len(lines)
+
+    total_tokens = estimate_tokens(text)
+    if total_tokens <= target_tokens * 1.5:
+        return [
+            {
+                "text": text,
+                "line_range": [1, total_lines],
+                "chunk_index": 0,
+                "overlap_prev": False,
+            }
+        ]
+
+    line_scores = [score_line(line, strategy) for line in lines]
+
+    chunks = []
+    chunk_start = 0
+
+    while chunk_start < total_lines:
+        token_count = 0
+        target_end = chunk_start
+        for i in range(chunk_start, total_lines):
+            line_tokens = estimate_tokens(lines[i]) if lines[i].strip() else 1
+            token_count += line_tokens
+            target_end = i
+            if token_count >= target_tokens:
+                break
+
+        if target_end >= total_lines - 1:
+            chunk_text_str = "\n".join(lines[chunk_start:])
+            chunks.append(
+                {
+                    "text": chunk_text_str,
+                    "line_range": [chunk_start + 1, total_lines],
+                    "chunk_index": len(chunks),
+                    "overlap_prev": chunk_start > 0 and overlap_tokens > 0 and len(chunks) > 0,
+                }
+            )
+            break
+
+        window_size = max(5, (target_end - chunk_start) // 5)
+        window_start = max(chunk_start + 1, target_end - window_size)
+        window_end = min(total_lines - 1, target_end + window_size)
+
+        best_boundary = target_end
+        best_score = -1
+        for i in range(window_start, window_end + 1):
+            if line_scores[i] > best_score:
+                best_score = line_scores[i]
+                best_boundary = i
+
+        if best_score <= 0:
+            best_boundary = target_end
+
+        if best_score >= 50 and HEADING_RE.match(lines[best_boundary]):
+            split_at = best_boundary
+        elif best_score >= 50 and (
+            SPEAKER_RE.match(lines[best_boundary])
+            or TIMESTAMP_RE.match(lines[best_boundary])
+            or CODE_BOUNDARY_RE.match(lines[best_boundary])
+        ):
+            split_at = best_boundary
+        else:
+            split_at = best_boundary + 1
+
+        chunk_text_str = "\n".join(lines[chunk_start:split_at])
+        if chunk_text_str.strip():
+            chunks.append(
+                {
+                    "text": chunk_text_str,
+                    "line_range": [chunk_start + 1, split_at],
+                    "chunk_index": len(chunks),
+                    "overlap_prev": chunk_start > 0 and overlap_tokens > 0 and len(chunks) > 0,
+                }
+            )
+
+        if overlap_tokens > 0 and split_at < total_lines:
+            overlap_lines = 0
+            overlap_token_count = 0
+            for i in range(split_at - 1, chunk_start, -1):
+                overlap_token_count += estimate_tokens(lines[i]) if lines[i].strip() else 1
+                overlap_lines += 1
+                if overlap_token_count >= overlap_tokens:
+                    break
+            chunk_start = max(chunk_start + 1, split_at - overlap_lines)
+        else:
+            chunk_start = split_at
+
+    return chunks
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Chunk a document by strategy")
+    parser.add_argument("file", help="Path to document file")
+    parser.add_argument(
+        "--strategy",
+        choices=["markdown", "transcript", "code", "paragraph"],
+        default="markdown",
+        help="Chunking strategy (default: markdown)",
+    )
+    parser.add_argument(
+        "--target-tokens",
+        type=int,
+        default=None,
+        help="Target chunk size in tokens",
+    )
+    parser.add_argument(
+        "--overlap-tokens",
+        type=int,
+        default=None,
+        help="Overlap between chunks in tokens",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output as JSON",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    file_path = Path(args.file)
+    if not file_path.exists():
+        print(f"Error: file not found: {args.file}", file=sys.stderr)
+        sys.exit(2)
+
+    text = file_path.read_text()
+    chunks = chunk_text(
+        text,
+        strategy=args.strategy,
+        target_tokens=args.target_tokens,
+        overlap_tokens=args.overlap_tokens,
+    )
+
+    if args.json_output:
+        print(json.dumps(chunks))
+    else:
+        for c in chunks:
+            lr = c["line_range"]
+            print(f"chunk-{c['chunk_index']}\tL{lr[0]}-{lr[1]}\t{len(c['text'])} chars")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(3)

--- a/lib/corpus/scripts/embed.py
+++ b/lib/corpus/scripts/embed.py
@@ -3,6 +3,7 @@
 
 Usage:
   python3 embed.py [--force] <index.yaml> <output.lance>
+  python3 embed.py --mode chunks [--force] <chunks.json> <output.lance>
 
 Reads entries from index.yaml including their concepts[] field.
 Embedding text: "passage: {title} | {summary} | {tags} | {concepts}"
@@ -27,6 +28,7 @@ from pathlib import Path
 MODEL_NAME = "BAAI/bge-small-en-v1.5"
 DIMENSIONS = 384
 TABLE_NAME = "embeddings"
+CHUNKS_TABLE_NAME = "chunks"
 META_TABLE = "_meta"
 PASSAGE_PREFIX = "passage: "  # bge-small asymmetric retrieval prefix for documents
 QUERY_PREFIX = "query: "  # bge-small asymmetric retrieval prefix for queries
@@ -35,12 +37,18 @@ VECTOR_INDEX_THRESHOLD = 500  # Create IVF_PQ index above this entry count
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Generate embeddings")
-    parser.add_argument("input", help="Path to index.yaml")
+    parser.add_argument("input", help="Path to index.yaml or chunks.json")
     parser.add_argument("output", help="Path to output Lance dataset directory")
     parser.add_argument(
         "--force",
         action="store_true",
         help="Force re-embedding all entries",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["index", "chunks"],
+        default="index",
+        help="Embedding mode: 'index' (default) embeds index.yaml entries, 'chunks' embeds chunk.py JSON output",
     )
     return parser.parse_args()
 
@@ -77,6 +85,25 @@ def load_entries(input_path):
                 "metadata_text": metadata_text.strip(),
             }
         )
+    return items
+
+
+def load_chunks(input_path):
+    """Load chunks from JSON file (output of chunk.py). Return list of dicts."""
+    with open(input_path) as f:
+        chunks = json.load(f)
+    items = []
+    for chunk in chunks:
+        items.append({
+            "id": chunk["id"],
+            "parent": chunk["parent"],
+            "source": chunk["source"],
+            "path": chunk["path"],
+            "chunk_index": chunk["chunk_index"],
+            "chunk_text": chunk["chunk_text"],
+            "line_range": chunk["line_range"],
+            "overlap_prev": chunk.get("overlap_prev", False),
+        })
     return items
 
 
@@ -120,8 +147,140 @@ def migrate_meta_json(output_path, db, pa):
             print(f"Warning: failed to migrate _meta.json: {e}", file=sys.stderr)
 
 
+def main_chunks(args):
+    """Handle the --mode chunks embedding pipeline."""
+    if not Path(args.input).exists():
+        print(f"Error: input file not found: {args.input}", file=sys.stderr)
+        sys.exit(2)
+
+    try:
+        from fastembed import TextEmbedding
+    except ImportError:
+        print(
+            "Error: fastembed not installed. "
+            "Run: pip install fastembed lancedb",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    try:
+        import lancedb
+        import pyarrow as pa
+    except ImportError:
+        print(
+            "Error: lancedb not installed. "
+            "Run: pip install fastembed lancedb",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Load chunks
+    try:
+        items = load_chunks(args.input)
+    except Exception as e:
+        print(f"Error: failed to parse input file: {e}", file=sys.stderr)
+        sys.exit(2)
+
+    if not items:
+        print("Warning: no chunks found in input file", file=sys.stderr)
+        sys.exit(2)
+
+    # Generate embeddings — no passage: prefix for raw content
+    print(f"Embedding {len(items)} chunks with {MODEL_NAME}...", file=sys.stderr)
+    model = TextEmbedding(model_name=MODEL_NAME)
+    texts = [item["chunk_text"] for item in items]
+    embeddings = list(model.embed(texts))
+
+    # Build PyArrow table with explicit schema
+    now = datetime.now(timezone.utc).isoformat()
+
+    schema = pa.schema(
+        [
+            pa.field("id", pa.string()),
+            pa.field("parent", pa.string()),
+            pa.field("source", pa.string()),
+            pa.field("path", pa.string()),
+            pa.field("chunk_index", pa.int64()),
+            pa.field("chunk_text", pa.string()),
+            pa.field("vector", pa.list_(pa.float32(), DIMENSIONS)),
+            pa.field("line_range", pa.list_(pa.int64())),
+            pa.field("overlap_prev", pa.bool_()),
+            pa.field("updated_at", pa.string()),
+        ]
+    )
+
+    records = []
+    for item, embedding in zip(items, embeddings):
+        records.append(
+            {
+                "id": item["id"],
+                "parent": item["parent"],
+                "source": item["source"],
+                "path": item["path"],
+                "chunk_index": item["chunk_index"],
+                "chunk_text": item["chunk_text"],
+                "vector": embedding.tolist(),
+                "line_range": item["line_range"],
+                "overlap_prev": item["overlap_prev"],
+                "updated_at": now,
+            }
+        )
+
+    arrow_table = pa.Table.from_pylist(records, schema=schema)
+
+    # Write Lance dataset
+    output_path = Path(args.output)
+    is_new = not output_path.exists()
+    db = lancedb.connect(str(output_path))
+
+    if args.force or is_new or CHUNKS_TABLE_NAME not in db.table_names():
+        tbl = db.create_table(CHUNKS_TABLE_NAME, data=arrow_table, mode="overwrite")
+    else:
+        tbl = db.open_table(CHUNKS_TABLE_NAME)
+        (
+            tbl.merge_insert("id")
+            .when_matched_update_all()
+            .when_not_matched_insert_all()
+            .execute(arrow_table)
+        )
+
+    # Create FTS index on chunk_text for hybrid search
+    try:
+        tbl.create_fts_index("chunk_text", replace=True)
+    except Exception as e:
+        print(f"Warning: FTS index creation failed: {e}", file=sys.stderr)
+
+    # Create vector index for large corpora
+    if len(records) > VECTOR_INDEX_THRESHOLD:
+        try:
+            tbl.create_index(metric="cosine")
+            print(
+                f"Created vector index ({len(records)} chunks "
+                f"> {VECTOR_INDEX_THRESHOLD})",
+                file=sys.stderr,
+            )
+        except Exception as e:
+            print(f"Warning: vector index creation failed: {e}", file=sys.stderr)
+
+    # Write metadata to _meta table
+    metadata = {
+        "model": MODEL_NAME,
+        "dimensions": DIMENSIONS,
+        "generated_at": now,
+        "chunk_count": len(records),
+    }
+    write_meta(db, metadata, pa)
+
+    total = len(records)
+    print(json.dumps({"total": total, "embedded": total, "dataset": str(output_path)}))
+
+
 def main():
     args = parse_args()
+
+    if args.mode == "chunks":
+        main_chunks(args)
+        return
 
     if not Path(args.input).exists():
         print(f"Error: input file not found: {args.input}", file=sys.stderr)

--- a/lib/corpus/scripts/search.py
+++ b/lib/corpus/scripts/search.py
@@ -153,7 +153,7 @@ def main():
         try:
             from lancedb.rerank import RRFReranker
             search = (
-                table.search(args.query, query_type="hybrid")
+                table.search(args.query, query_type="hybrid", fts_columns=args.text_column)
                 .rerank(reranker=RRFReranker())
                 .limit(args.top_k)
             )

--- a/lib/corpus/scripts/search.py
+++ b/lib/corpus/scripts/search.py
@@ -54,6 +54,21 @@ def parse_args():
         dest="json_output",
         help="Output as JSON",
     )
+    parser.add_argument(
+        "--table",
+        default=TABLE_NAME,
+        help="Table name to search within the Lance database (default: embeddings)",
+    )
+    parser.add_argument(
+        "--hybrid",
+        action="store_true",
+        help="Use hybrid search (FTS + vector + RRF) instead of vector-only",
+    )
+    parser.add_argument(
+        "--text-column",
+        default="metadata_text",
+        help="Text column for hybrid FTS search (default: metadata_text)",
+    )
     return parser.parse_args()
 
 
@@ -115,9 +130,9 @@ def main():
     db = lancedb.connect(str(dataset_path))
 
     try:
-        table = db.open_table(TABLE_NAME)
+        table = db.open_table(args.table)
     except Exception as e:
-        print(f"Error: could not open dataset: {e}", file=sys.stderr)
+        print(f"Error: could not open table '{args.table}': {e}", file=sys.stderr)
         sys.exit(2)
 
     # Check model match
@@ -134,29 +149,37 @@ def main():
     model = TextEmbedding(model_name=MODEL_NAME)
     query_embedding = list(model.embed([f"{QUERY_PREFIX}{args.query}"]))[0]
 
-    # Build search query with cosine metric
-    search = (
-        table.search(query_embedding.tolist(), vector_column_name="vector")
-        .metric("cosine")
-        .limit(args.top_k)
-    )
+    if args.hybrid:
+        try:
+            from lancedb.rerank import RRFReranker
+            search = (
+                table.search(args.query, query_type="hybrid")
+                .rerank(reranker=RRFReranker())
+                .limit(args.top_k)
+            )
+        except ImportError:
+            print("Warning: RRFReranker not available, falling back to vector search", file=sys.stderr)
+            search = (
+                table.search(query_embedding.tolist(), vector_column_name="vector")
+                .metric("cosine")
+                .limit(args.top_k)
+            )
+    else:
+        search = (
+            table.search(query_embedding.tolist(), vector_column_name="vector")
+            .metric("cosine")
+            .limit(args.top_k)
+        )
 
-    # Add SQL predicate if provided
     if args.where:
         search = search.where(args.where)
 
-    # Apply reranking if requested
     if args.rerank:
         try:
             from lancedb.rerank import CrossEncoderReranker
-
             search = search.rerank(reranker=CrossEncoderReranker())
         except ImportError:
-            print(
-                "Warning: reranking not available "
-                "(lancedb rerank module missing)",
-                file=sys.stderr,
-            )
+            print("Warning: reranking not available", file=sys.stderr)
         except Exception as e:
             print(f"Warning: reranking failed: {e}", file=sys.stderr)
 
@@ -170,7 +193,14 @@ def main():
 
     # Format results
     ids = arrow_result.column("id").to_pylist()
-    distances = arrow_result.column("_distance").to_pylist()
+
+    # Hybrid search returns _relevance_score, vector search returns _distance
+    if "_relevance_score" in arrow_result.schema.names:
+        raw_scores = arrow_result.column("_relevance_score").to_pylist()
+        scores = [max(0.0, float(s)) for s in raw_scores]
+    else:
+        distances = arrow_result.column("_distance").to_pylist()
+        scores = [max(0.0, 1.0 - float(d)) for d in distances]
 
     # Determine extra columns to include (--select requires --json)
     select_cols = []
@@ -178,8 +208,7 @@ def main():
         select_cols = [c.strip() for c in args.select.split(",")]
 
     results = []
-    for i, (entry_id, distance) in enumerate(zip(ids, distances)):
-        score = max(0.0, 1.0 - float(distance))
+    for i, (entry_id, score) in enumerate(zip(ids, scores)):
         result = {"id": entry_id, "score": round(score, 4)}
 
         # Add selected columns

--- a/lib/corpus/scripts/tests/test_chunk.py
+++ b/lib/corpus/scripts/tests/test_chunk.py
@@ -1,0 +1,192 @@
+"""Tests for chunk.py — deterministic document chunking.
+
+Unit tests (no external deps):
+  - Markdown strategy boundary detection
+  - Transcript strategy boundary detection
+  - Paragraph strategy boundary detection
+  - Overlap handling
+  - Edge cases (empty file, single line, file smaller than target)
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+class TestMarkdownStrategy:
+    """Markdown chunking: headings (100), blank lines (20), list items (10)."""
+
+    def test_splits_on_headings(self):
+        from chunk import chunk_text
+
+        text = "\n".join([
+            "# Introduction",
+            "First paragraph of intro.",
+            "Second paragraph of intro.",
+            "",
+            "## Getting Started",
+            "Content for getting started section.",
+            "More content here with details.",
+            "",
+            "## Advanced Usage",
+            "Advanced content goes here.",
+            "Even more advanced content.",
+        ])
+        chunks = chunk_text(text, strategy="markdown", target_tokens=20, overlap_tokens=0)
+        assert len(chunks) >= 2
+        assert "text" in chunks[0]
+        assert "line_range" in chunks[0]
+        assert "chunk_index" in chunks[0]
+        assert chunks[0]["chunk_index"] == 0
+        assert chunks[1]["chunk_index"] == 1
+
+    def test_respects_target_size(self):
+        from chunk import chunk_text
+
+        lines = [f"Line {i} with some content to fill space." for i in range(100)]
+        text = "\n".join(lines)
+        chunks = chunk_text(text, strategy="markdown", target_tokens=50, overlap_tokens=0)
+        for c in chunks:
+            word_count = len(c["text"].split())
+            assert word_count < 150, f"Chunk too large: {word_count} words"
+
+    def test_overlap_produces_shared_content(self):
+        from chunk import chunk_text
+
+        lines = []
+        for i in range(5):
+            lines.append(f"## Section {i}")
+            lines.extend([f"Content line {i}-{j}." for j in range(10)])
+            lines.append("")
+        text = "\n".join(lines)
+        chunks = chunk_text(text, strategy="markdown", target_tokens=30, overlap_tokens=10)
+        if len(chunks) >= 2:
+            assert chunks[1].get("overlap_prev", False) is True
+
+    def test_small_file_single_chunk(self):
+        from chunk import chunk_text
+
+        text = "Just a small file.\nWith two lines."
+        chunks = chunk_text(text, strategy="markdown", target_tokens=900, overlap_tokens=100)
+        assert len(chunks) == 1
+        assert chunks[0]["line_range"] == [1, 2]
+
+    def test_empty_file_returns_empty(self):
+        from chunk import chunk_text
+
+        chunks = chunk_text("", strategy="markdown", target_tokens=900, overlap_tokens=100)
+        assert chunks == []
+
+
+class TestTranscriptStrategy:
+    """Transcript chunking: speaker turns (80), timestamps (50), blank lines (20)."""
+
+    def test_splits_on_speaker_turns(self):
+        from chunk import chunk_text
+
+        text = "\n".join([
+            "Alice: Hello everyone, let's get started with the meeting.",
+            "Alice: First item on the agenda is the Q3 review.",
+            "",
+            "Bob: Thanks Alice. The numbers look good this quarter.",
+            "Bob: Revenue is up 15% compared to last quarter.",
+            "",
+            "Charlie: I have some concerns about the infrastructure costs.",
+            "Charlie: We need to discuss the cloud spending.",
+        ])
+        chunks = chunk_text(text, strategy="transcript", target_tokens=20, overlap_tokens=0)
+        assert len(chunks) >= 2
+
+    def test_splits_on_timestamps(self):
+        from chunk import chunk_text
+
+        text = "\n".join([
+            "[00:00:00] Meeting started",
+            "Discussion about project timeline.",
+            "More discussion here.",
+            "",
+            "[00:15:00] Moving to next topic",
+            "Budget review discussion.",
+            "More budget details.",
+            "",
+            "[00:30:00] Action items",
+            "List of things to do.",
+        ])
+        chunks = chunk_text(text, strategy="transcript", target_tokens=20, overlap_tokens=0)
+        assert len(chunks) >= 2
+
+
+class TestParagraphStrategy:
+    """Paragraph chunking: double newlines (50), single newlines (10)."""
+
+    def test_splits_on_double_newlines(self):
+        from chunk import chunk_text
+
+        paragraphs = []
+        for i in range(10):
+            paragraphs.append(f"Paragraph {i} with enough content to matter. " * 5)
+        text = "\n\n".join(paragraphs)
+        chunks = chunk_text(text, strategy="paragraph", target_tokens=50, overlap_tokens=0)
+        assert len(chunks) >= 2
+
+
+class TestLineRanges:
+    """Verify line_range accuracy across all strategies."""
+
+    def test_line_ranges_are_contiguous(self):
+        from chunk import chunk_text
+
+        lines = [f"Line {i}" for i in range(50)]
+        text = "\n".join(lines)
+        chunks = chunk_text(text, strategy="paragraph", target_tokens=20, overlap_tokens=0)
+
+        for i in range(len(chunks) - 1):
+            current_end = chunks[i]["line_range"][1]
+            next_start = chunks[i + 1]["line_range"][0]
+            assert next_start <= current_end + 1
+
+    def test_line_ranges_cover_entire_file(self):
+        from chunk import chunk_text
+
+        lines = [f"Line {i}" for i in range(50)]
+        text = "\n".join(lines)
+        chunks = chunk_text(text, strategy="paragraph", target_tokens=20, overlap_tokens=0)
+
+        assert chunks[0]["line_range"][0] == 1
+        assert chunks[-1]["line_range"][1] == 50
+
+
+class TestCLI:
+    """Test command-line interface."""
+
+    def test_cli_json_output(self, tmp_path):
+        import subprocess
+
+        doc = tmp_path / "test.md"
+        doc.write_text("# Title\n\nSome content.\n\n## Section\n\nMore content.\n")
+
+        result = subprocess.run(
+            [sys.executable, "lib/corpus/scripts/chunk.py",
+             str(doc), "--strategy", "markdown",
+             "--target-tokens", "10", "--json"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert isinstance(data, list)
+        assert len(data) >= 1
+        assert "text" in data[0]
+        assert "line_range" in data[0]
+
+    def test_cli_missing_file(self):
+        import subprocess
+
+        result = subprocess.run(
+            [sys.executable, "lib/corpus/scripts/chunk.py",
+             "/nonexistent/file.md", "--strategy", "markdown"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 2

--- a/lib/corpus/scripts/tests/test_chunk.py
+++ b/lib/corpus/scripts/tests/test_chunk.py
@@ -133,6 +133,29 @@ class TestParagraphStrategy:
         assert len(chunks) >= 2
 
 
+class TestCodeStrategy:
+    """Code chunking: function/class boundaries (100), blank lines (20)."""
+
+    def test_splits_on_function_definitions(self):
+        from chunk import chunk_text
+
+        text = "\n".join([
+            "def hello():",
+            "    print('hello')",
+            "    print('world')",
+            "",
+            "def goodbye():",
+            "    print('goodbye')",
+            "    print('world')",
+            "",
+            "class MyClass:",
+            "    def method(self):",
+            "        pass",
+        ])
+        chunks = chunk_text(text, strategy="code", target_tokens=10, overlap_tokens=0)
+        assert len(chunks) >= 2
+
+
 class TestLineRanges:
     """Verify line_range accuracy across all strategies."""
 

--- a/lib/corpus/scripts/tests/test_embed.py
+++ b/lib/corpus/scripts/tests/test_embed.py
@@ -301,5 +301,103 @@ class TestEmbeddingPipeline:
         assert "_meta" in db2.table_names()
 
 
+@pytest.fixture
+def sample_chunks_json(tmp_path):
+    """Create a chunks JSON file matching chunk.py output format."""
+    chunks = [
+        {"id": "test:doc1.md#chunk-0", "parent": "test:doc1.md", "source": "test",
+         "path": "doc1.md", "chunk_index": 0,
+         "chunk_text": "Getting started with the project requires installing dependencies first.",
+         "line_range": [1, 10], "overlap_prev": False},
+        {"id": "test:doc1.md#chunk-1", "parent": "test:doc1.md", "source": "test",
+         "path": "doc1.md", "chunk_index": 1,
+         "chunk_text": "The API provides endpoints for creating, reading, and deleting resources.",
+         "line_range": [8, 20], "overlap_prev": True},
+        {"id": "test:doc2.md#chunk-0", "parent": "test:doc2.md", "source": "test",
+         "path": "doc2.md", "chunk_index": 0,
+         "chunk_text": "Performance tuning involves optimizing database queries and caching strategies.",
+         "line_range": [1, 15], "overlap_prev": False},
+    ]
+    path = tmp_path / "chunks.json"
+    path.write_text(json.dumps(chunks))
+    return path
+
+
+class TestChunkMode:
+    """Test --mode chunks for chunk embedding pipeline."""
+
+    def test_missing_mode_chunks_input(self, tmp_path):
+        """Exit code 2 when chunks input file doesn't exist."""
+        result = subprocess.run(
+            [sys.executable, SCRIPT, "--mode", "chunks",
+             "/nonexistent/chunks.json", str(tmp_path / "out.lance")],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 2
+
+
+@pytest.mark.skipif(not deps_available(), reason="fastembed/lancedb not installed")
+class TestChunkEmbeddingPipeline:
+    """End-to-end tests for chunk embedding."""
+
+    def test_chunk_mode_creates_chunks_table(self, sample_chunks_json, tmp_path):
+        import lancedb
+        output = tmp_path / "chunks-embeddings.lance"
+        result = subprocess.run(
+            [sys.executable, SCRIPT, "--mode", "chunks",
+             str(sample_chunks_json), str(output)],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, f"Failed: {result.stderr}"
+        db = lancedb.connect(str(output))
+        assert "chunks" in db.table_names()
+        table = db.open_table("chunks")
+        assert "chunk_text" in table.schema.names
+        assert "vector" in table.schema.names
+        assert "parent" in table.schema.names
+        assert "chunk_index" in table.schema.names
+        assert table.count_rows() == 3
+
+    def test_chunk_mode_creates_fts_index(self, sample_chunks_json, tmp_path):
+        output = tmp_path / "chunks-embeddings.lance"
+        subprocess.run(
+            [sys.executable, SCRIPT, "--mode", "chunks",
+             str(sample_chunks_json), str(output)],
+            capture_output=True,
+        )
+        import lancedb
+        db = lancedb.connect(str(output))
+        table = db.open_table("chunks")
+        assert "chunk_text" in table.schema.names
+
+    def test_chunk_mode_meta_table(self, sample_chunks_json, tmp_path):
+        import lancedb
+        output = tmp_path / "chunks-embeddings.lance"
+        subprocess.run(
+            [sys.executable, SCRIPT, "--mode", "chunks",
+             str(sample_chunks_json), str(output)],
+            capture_output=True,
+        )
+        db = lancedb.connect(str(output))
+        meta_table = db.open_table("_meta")
+        meta_arrow = meta_table.to_arrow()
+        keys = meta_arrow.column("key").to_pylist()
+        values = meta_arrow.column("value").to_pylist()
+        meta = dict(zip(keys, values))
+        assert meta["model"] == "BAAI/bge-small-en-v1.5"
+        assert meta["chunk_count"] == "3"
+
+    def test_chunk_mode_json_output(self, sample_chunks_json, tmp_path):
+        output = tmp_path / "chunks-embeddings.lance"
+        result = subprocess.run(
+            [sys.executable, SCRIPT, "--mode", "chunks",
+             str(sample_chunks_json), str(output)],
+            capture_output=True, text=True,
+        )
+        output_json = json.loads(result.stdout)
+        assert output_json["total"] == 3
+        assert output_json["embedded"] == 3
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/lib/corpus/scripts/tests/test_search.py
+++ b/lib/corpus/scripts/tests/test_search.py
@@ -251,6 +251,109 @@ class TestSearchPipeline:
         parts = lines[0].split("\t")
         assert len(parts) == 2  # score + id only
 
+    def test_table_parameter_uses_named_table(self, embedded_dataset):
+        """--table selects a specific table within the Lance database."""
+        result = subprocess.run(
+            [sys.executable, SCRIPT, str(embedded_dataset),
+             "database performance", "--table", "embeddings", "--json"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        results = json.loads(result.stdout)
+        assert len(results) > 0
+
+    def test_table_parameter_missing_table_exits_2(self, embedded_dataset):
+        """--table with nonexistent table name exits 2."""
+        result = subprocess.run(
+            [sys.executable, SCRIPT, str(embedded_dataset),
+             "query", "--table", "nonexistent"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 2
+        assert "could not open" in result.stderr.lower()
+
+
+class TestHybridSearch:
+    """Tests for --hybrid mode (FTS + vector + RRF)."""
+
+    @pytest.fixture
+    def chunk_dataset(self, tmp_path):
+        """Build a Lance dataset with chunk_text column for hybrid search testing."""
+        import lancedb
+        import pyarrow as pa
+        from fastembed import TextEmbedding
+
+        db = lancedb.connect(str(tmp_path / "chunks.lance"))
+        model = TextEmbedding(model_name="BAAI/bge-small-en-v1.5")
+
+        records = [
+            {"id": "src:file.md#chunk-0", "parent": "src:file.md", "source": "src",
+             "chunk_text": "Python is a great programming language for data science and machine learning.",
+             "chunk_index": 0},
+            {"id": "src:file.md#chunk-1", "parent": "src:file.md", "source": "src",
+             "chunk_text": "Italian cooking involves pasta, pizza, olive oil and fresh tomatoes.",
+             "chunk_index": 1},
+            {"id": "src:other.md#chunk-0", "parent": "src:other.md", "source": "src",
+             "chunk_text": "Cloud deployment on AWS requires configuring EC2 instances and load balancers.",
+             "chunk_index": 0},
+        ]
+
+        texts = [r["chunk_text"] for r in records]
+        embeddings = list(model.embed(texts))
+
+        schema = pa.schema([
+            pa.field("id", pa.string()),
+            pa.field("parent", pa.string()),
+            pa.field("source", pa.string()),
+            pa.field("chunk_text", pa.string()),
+            pa.field("chunk_index", pa.int64()),
+            pa.field("vector", pa.list_(pa.float32(), 384)),
+        ])
+
+        for rec, emb in zip(records, embeddings):
+            rec["vector"] = emb.tolist()
+
+        tbl = db.create_table("chunks", data=pa.Table.from_pylist(records, schema=schema))
+        tbl.create_fts_index("chunk_text", replace=True)
+
+        meta_schema = pa.schema([pa.field("key", pa.string()), pa.field("value", pa.string())])
+        meta_records = [
+            {"key": "model", "value": "BAAI/bge-small-en-v1.5"},
+            {"key": "dimensions", "value": "384"},
+        ]
+        db.create_table("_meta", data=pa.Table.from_pylist(meta_records, schema=meta_schema))
+
+        return tmp_path / "chunks.lance"
+
+    @pytest.mark.skipif(not deps_available(), reason="fastembed/lancedb not installed")
+    def test_hybrid_search_returns_results(self, chunk_dataset):
+        """--hybrid with --table chunks returns results using FTS+vector."""
+        result = subprocess.run(
+            [sys.executable, SCRIPT, str(chunk_dataset),
+             "python data science", "--table", "chunks",
+             "--hybrid", "--text-column", "chunk_text", "--json"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        results = json.loads(result.stdout)
+        assert len(results) > 0
+        assert results[0]["id"] == "src:file.md#chunk-0"
+
+    @pytest.mark.skipif(not deps_available(), reason="fastembed/lancedb not installed")
+    def test_hybrid_returns_extra_columns(self, chunk_dataset):
+        """--hybrid with --select returns requested columns."""
+        result = subprocess.run(
+            [sys.executable, SCRIPT, str(chunk_dataset),
+             "deploy cloud AWS", "--table", "chunks",
+             "--hybrid", "--text-column", "chunk_text",
+             "--select", "parent,chunk_text", "--json"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        results = json.loads(result.stdout)
+        assert "parent" in results[0]
+        assert "chunk_text" in results[0]
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/skills/hiivmind-corpus-build/SKILL.md
+++ b/skills/hiivmind-corpus-build/SKILL.md
@@ -136,6 +136,23 @@ extraction_config:
 Include extraction output in your YAML report per the extraction output format in
 ${CLAUDE_PLUGIN_ROOT}/lib/corpus/patterns/extraction.md § "Source-Scanner Extraction Output Format".
 {end if}
+{if source has sections: block in config}
+sections_config:
+  enabled: true
+  min_level: {min_level}
+  min_content_lines: {min_content_lines}
+Generate section entries for qualifying headings per the Section Entry Generation
+instructions in ${CLAUDE_PLUGIN_ROOT}/agents/source-scanner.md.
+Also report heading_consistency in your scan output.
+{end if}
+{if source has chunking: block in config}
+chunking_config:
+  strategy: {strategy}
+  target_tokens: {target_tokens}
+  overlap_tokens: {overlap_tokens}
+Run chunk.py on each file and include chunks in your output per the Chunk Generation
+instructions in ${CLAUDE_PLUGIN_ROOT}/agents/source-scanner.md.
+{end if}
 Additionally, for each documentation file, include entry metadata in your output:
 path, title, summary, tags, keywords, category, content_type, size, grep_hint, headings.
 See ${CLAUDE_PLUGIN_ROOT}/agents/source-scanner.md § "Entry Metadata Generation" for field details.
@@ -243,6 +260,61 @@ Ask: "How should the index be organized?"
 Ask: "Are there sections to exclude? (e.g., changelog, internal docs)"
 Allow comma-separated section names or "none".
 
+### Indexing depth (per source)
+
+**See:** `${CLAUDE_PLUGIN_ROOT}/lib/corpus/patterns/section-indexing.md` and `${CLAUDE_PLUGIN_ROOT}/lib/corpus/patterns/chunking.md`
+
+For each source, analyze scan results and recommend an indexing depth. Present
+the recommendation with concrete consequences — estimated counts and sizes.
+
+For each source, present:
+
+```
+Source: {source_id} ({type}, {file_count} files, {large_file_count} large files)
+
+Recommended indexing depth: {recommendation}
+  - File-level: {file_count} entries with metadata embeddings (current default)
+  - Section-level: ~{section_estimate} additional entries from h{min_level}+ headings
+  - Deep chunking: {chunk_estimate_or_"Not recommended"} using {strategy} strategy
+
+Reason: {explanation based on scan results}
+
+Options:
+  a) File only (current behavior)
+  b) File + Sections [recommended if heading_consistency is high]
+  c) File + Chunks [recommended if heading_consistency is low]
+  d) File + Sections + Chunks
+```
+
+**Recommendation logic:**
+
+| Scan Result | Recommendation |
+|------------|---------------|
+| heading_consistency: high, large_files > 0 | File + Sections |
+| heading_consistency: low or mixed | File + Chunks |
+| heading_consistency: high, large_files > 0, file_count > 200 | File + Sections + Chunks |
+| file_count < 50, no large files | File only |
+
+**Estimation heuristics:**
+- Section count: `sum(headings per file at min_level+) * 0.7` (30% filtered by min_content_lines)
+- Chunk count: `sum(file_lines / target_lines_per_chunk)` across chunking-eligible files
+- Embedding size: `entry_count * 2KB` for metadata, `chunk_count * 15KB` for chunks
+
+After all sources are configured, show a confirmation table:
+
+```
+Indexing Depth Summary
+──────────────────────────────────────────────────────────────
+Source            | File | Sections | Chunks | Est. size
+------------------|------|----------|--------|----------
+polars-docs       |  142 |     ~200 |      — | ~4MB
+meeting-notes     |  340 |        — |  ~3000 | ~45MB
+obsidian-vault    |  215 |     ~180 |   ~800 | ~18MB
+──────────────────────────────────────────────────────────────
+```
+
+Store user choices in `computed.indexing_depth` for use in later phases.
+
 ---
 
 ## Phase 5: Generate Index
@@ -296,6 +368,13 @@ For each entry from each source-scanner report:
 6. Set `frontmatter` from extraction frontmatter data (if available, else `{}`)
 7. Set `concepts` to empty list `[]` (populated later by Phase 6 if graph extraction is enabled, or manually via graph add-concept)
 8. Set `stale: false`, `stale_since: null`, `last_indexed` to current timestamp
+9. For section entries from source-scanner reports (entries with `tier: section`):
+   - Construct `id` as `{source_id}:{path}#{anchor}`
+   - Set `parent` to the file entry ID (`{source_id}:{path}`)
+   - Map scanner output: `title`, `summary`, `tags`, `keywords`, `anchor`, `heading_level`, `line_range`
+   - Set `tier: section`
+   - Set `concepts` to empty list (populated by Phase 6 if applicable)
+   - Section entries do NOT have: `size`, `grep_hint`, `headings`, `links_to`, `links_from`, `frontmatter`
 
 Construct `meta`:
 - `generated_at`: current timestamp
@@ -448,6 +527,38 @@ GUARD_PHASE_7():
 
 ---
 
+## Phase 7b: Generate Chunk Embeddings (optional)
+
+**Inputs:** `computed.scan_results` (with chunks data), `computed.indexing_depth`
+**Outputs:** `chunks-embeddings.lance/` (if any source has chunking enabled)
+
+**Skip condition:** No source in `computed.indexing_depth` has chunks enabled.
+
+### Procedure
+
+1. Aggregate all chunks from source-scanner reports into a single JSON file:
+   - Write `chunks.json` to a temporary location
+   - Each chunk must have: `id`, `parent`, `source`, `path`, `chunk_index`, `chunk_text`, `line_range`, `overlap_prev`
+
+2. Run dependency detection:
+   ```bash
+   python3 ${CLAUDE_PLUGIN_ROOT}/lib/corpus/scripts/detect.py
+   ```
+   If not installed, prompt user (same as Phase 7).
+
+3. Run chunk embedding:
+   ```bash
+   python3 ${CLAUDE_PLUGIN_ROOT}/lib/corpus/scripts/embed.py --mode chunks chunks.json chunks-embeddings.lance/
+   ```
+
+4. Clean up temporary `chunks.json`
+
+5. Display: "Generated chunk embeddings for {chunk_count} chunks across {source_count} sources"
+
+**Commit guidance:** `chunks-embeddings.lance/` MUST be committed alongside other corpus files. Do NOT add to `.gitignore`.
+
+---
+
 ## Phase 8: Save and Complete
 
 **Inputs:** `computed.index`, `computed.segmentation`
@@ -484,10 +595,11 @@ Display summary:
 ```
 Build complete!
 
-Index: index.yaml ({entry_count} entries)
+Index: index.yaml ({entry_count} entries, {section_count} sections)
 Rendered: index.md
 {if graph: Graph: graph.yaml ({concept_count} concepts, {relationship_count} relationships)}
-{if embeddings: Embeddings: index-embeddings.lance/ ({entry_count} entries)}
+{if embeddings: Embeddings: index-embeddings.lance/ ({entry_count + section_count} entries)}
+{if chunks: Chunks: chunks-embeddings.lance/ ({chunk_count} chunks)}
 {if tiered: Sub-indexes: {count} files}
 Strategy: {segmentation_strategy}
 Sources indexed: {source_count}
@@ -521,6 +633,8 @@ Sources indexed: {source_count}
 - **Index rendering:** `${CLAUDE_PLUGIN_ROOT}/lib/corpus/patterns/index-rendering.md`
 - **Freshness:** `${CLAUDE_PLUGIN_ROOT}/lib/corpus/patterns/freshness.md`
 - **Embeddings:** `${CLAUDE_PLUGIN_ROOT}/lib/corpus/patterns/embeddings.md`
+- **Section indexing:** `${CLAUDE_PLUGIN_ROOT}/lib/corpus/patterns/section-indexing.md`
+- **Deep chunking:** `${CLAUDE_PLUGIN_ROOT}/lib/corpus/patterns/chunking.md`
 
 ## Agent
 

--- a/skills/hiivmind-corpus-navigate/SKILL.md
+++ b/skills/hiivmind-corpus-navigate/SKILL.md
@@ -167,6 +167,28 @@ Read: {source.path}/index.md
 
 ### Phase 4: Search Index
 
+#### Step 4-pre: Query Expansion (if chunks-embeddings exists)
+
+Check if `chunks-embeddings.lance/` exists for the selected corpus:
+- **Local/embedded:** `{corpus_path}/chunks-embeddings.lance/`
+- **Remote:** `.hiivmind/corpus/cache/{corpus_id}/chunks-embeddings.lance/`
+
+If it exists:
+
+1. Generate 2 query variants:
+   - **Lexical variant:** Reformulate the query using specific keywords, function names, identifiers
+   - **Conceptual variant:** Reformulate using synonyms, broader concepts, related terminology
+2. Store all 3 queries: `[original, lexical_variant, conceptual_variant]`
+
+Example:
+- Original: "how do I filter by date"
+- Lexical: "date filter timestamp column"
+- Conceptual: "temporal predicates datetime expressions"
+
+If `chunks-embeddings.lance/` does not exist: skip, use only the original query.
+
+Can be disabled with `query_expansion: false` in the corpus config.yaml.
+
 #### If index.yaml was fetched (v2 flow):
 
 **Step 4a: Embedding pre-filter** (if index-embeddings.lance/ exists)
@@ -198,6 +220,46 @@ Use `lance_path` in all subsequent search.py invocations in this phase.
    - Feed top 15 entries to Step 4b (LLM semantic judgment)
    - Skip the yq pre-filter below
 5. If search.py exits non-zero or no results: fall through to yq pre-filter
+
+**Step 4a-chunks: Chunk search** (if chunks-embeddings.lance/ exists)
+
+Resolve chunk lance path:
+- **Local/embedded:** `chunks_lance_path = {corpus_path}/chunks-embeddings.lance/`
+- **Remote:** `chunks_lance_path = .hiivmind/corpus/cache/{corpus_id}/chunks-embeddings.lance/`
+
+If path exists:
+
+For each query (original + variants from Step 4-pre):
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/lib/corpus/scripts/search.py {chunks_lance_path} "{query}" \
+  --table chunks --hybrid --text-column chunk_text --top-k 15 \
+  --select "parent,chunk_text,line_range" --json
+```
+
+Merge results across queries: deduplicate by `id`, keep highest score per chunk,
+weight original query results 2x.
+
+**Step 4a-fusion: Fuse results across tiers**
+
+If both index-embeddings and chunks-embeddings returned results:
+
+1. **Normalize scores per tier:** Divide each score by the max score in its tier
+   (so both tiers have scores in 0-1 range).
+
+2. **Parent-child deduplication:** For each chunk hit, check if its `parent` field
+   matches any file/section hit's `id`:
+   - If match: boost the parent's normalized score by +0.1, attach the chunk's
+     `line_range` to the parent entry (so the LLM knows which section is relevant).
+     Remove the chunk from the results.
+   - If no match: keep the chunk as a standalone result with its `parent` and
+     `line_range` for context.
+
+3. **Merge:** Combine remaining results from both tiers, sort by normalized score,
+   take top 15.
+
+4. Feed merged results to Step 4b (LLM semantic judgment).
+
+If only one tier returned results: skip fusion, use that tier's results directly.
 
 **See:** `${CLAUDE_PLUGIN_ROOT}/lib/corpus/patterns/embeddings.md` § Graph-Boost, Reranking
 
@@ -360,7 +422,7 @@ TTL_DAYS=${TTL_DAYS:-7}
 TMPDIR=$(mktemp -d)
 git clone --depth 1 --filter=blob:none --sparse \
   "https://github.com/{owner}/{repo}.git" "$TMPDIR" 2>/dev/null
-cd "$TMPDIR" && git sparse-checkout set index-embeddings.lance
+cd "$TMPDIR" && git sparse-checkout set index-embeddings.lance chunks-embeddings.lance
 
 if [ ! -d "$TMPDIR/index-embeddings.lance" ]; then
   rm -rf "$TMPDIR"
@@ -376,6 +438,14 @@ rm -rf "$CACHE_DIR/index-embeddings.lance.tmp"
 cp -r "$TMPDIR/index-embeddings.lance" "$CACHE_DIR/index-embeddings.lance.tmp"
 rm -rf "$CACHE_DIR/index-embeddings.lance"
 mv "$CACHE_DIR/index-embeddings.lance.tmp" "$CACHE_DIR/index-embeddings.lance"
+
+# Copy chunks-embeddings.lance (new)
+if [ -d "$TMPDIR/chunks-embeddings.lance" ]; then
+  rm -rf "$CACHE_DIR/chunks-embeddings.lance.tmp"
+  cp -r "$TMPDIR/chunks-embeddings.lance" "$CACHE_DIR/chunks-embeddings.lance.tmp"
+  rm -rf "$CACHE_DIR/chunks-embeddings.lance"
+  mv "$CACHE_DIR/chunks-embeddings.lance.tmp" "$CACHE_DIR/chunks-embeddings.lance"
+fi
 
 cat > "$CACHE_DIR/_cache_meta.json" << EOF
 {
@@ -422,6 +492,10 @@ rm -rf "$TMPDIR"
 | Remote corpus, cache stale and SHA changed | Re-clone Lance directory (~5s) |
 | Remote corpus, network unavailable | Use existing cache if present, else yq pre-filter |
 | git not available | Skip sparse clone, fall through to yq pre-filter |
+| No chunks-embeddings.lance/ | Skip chunk search, use metadata embeddings only |
+| chunks-embeddings.lance/ but no fastembed | Skip chunk search, fall back to metadata-only |
+| Stale chunk embeddings | Use them, note in output |
+| query_expansion: false in config | Skip query expansion, search with original query only |
 
 ### Phase 5: Fetch Documentation
 


### PR DESCRIPTION
## Summary

- **chunk.py**: New deterministic boundary detection script with 4 strategies (markdown, transcript, code, paragraph) and configurable target/overlap tokens
- **search.py**: Extended with `--table`, `--hybrid` (LanceDB FTS+vector+RRF), and `--text-column` for chunk search
- **embed.py**: Extended with `--mode chunks` for content-level embedding into separate `chunks-embeddings.lance/` file
- **Section-level indexing**: `tier: section` sub-entries in `index.yaml` with heading-bounded metadata embeddings in existing `index-embeddings.lance/`
- **Deep chunking**: ~900-token content chunks embedded into `chunks-embeddings.lance/` with LanceDB native hybrid search
- **Navigate fusion**: Searches both Lance files, deduplicates parent-child hits, normalizes scores, query expansion for chunk tier
- **Build skill UX**: Per-source indexing depth recommendations with estimated counts and sizes, confirmation table

## Test Plan

- [x] 50/50 tests pass (13 chunk, 17 embed, 16 search, 4 detect)
- [ ] Manual: build a corpus with `sections.enabled: true` on a structured docs source
- [ ] Manual: build a corpus with `chunking.enabled: true` on meeting transcripts
- [ ] Manual: navigate query hits both tiers and fuses results correctly
- [ ] Verify existing corpora without sections/chunking config are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)