### PR TITLE
feat: PageIndex-inspired build enhancements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,6 +297,11 @@ These features span multiple skills and must stay synchronized:
 | Concept membership | build, graph, enhance, refresh, navigate | `concepts[]` field in index.yaml entries, bidirectional with graph.yaml concept definitions, enriches embedding text |
 | Section indexing | build, source-scanner, navigate, enhance, refresh | `sections:` config, `tier: section` entries, heading consistency detection, line_range in index.yaml |
 | Deep chunking | build, source-scanner, navigate, enhance, refresh | `chunking:` config, chunk.py invocation, `chunks-embeddings.lance/` generation/query, hybrid search, query expansion |
+| Nav detection | source-scanner, build, add-source | `detect_nav.py` called before glob scan, coverage threshold logic |
+| Verification loop | build, refresh | `verify_entries.py` + LLM verification, config flag |
+| Tree thinning | build, enhance, refresh | `thin_sections.py` post-processing, `min_section_tokens` config |
+| Large-node splitting | source-scanner, build | `detect_large_files.py` + `split_by_headings.py`, interaction with section indexing |
+| Structure-aware chunking | build, source-scanner, navigate | `headings` strategy in `chunk.py`, `heading_context` in embeddings |
 
 ### When Adding New Features
 
@@ -336,6 +341,10 @@ navigate ◄── index-embeddings.lance/ (retrieval + cross-corpus routing)
 graph ◄── index-embeddings.lance/ (relationship candidate detection)
 build ──► chunks-embeddings.lance/ (optional, Phase 7b)
 navigate ◄── chunks-embeddings.lance/ (hybrid search + fusion)
+build ──► detect_nav.py, detect_large_files.py, split_by_headings.py (via source-scanner, Phase 2)
+build ──► thin_sections.py (post Phase 2c)
+build ──► verify_entries.py (Phase 7c)
+refresh ──► verify_entries.py (post Phase 6)
 ```
 
 ### Reference Sections

--- a/agents/source-scanner.md
+++ b/agents/source-scanner.md
@@ -36,6 +36,19 @@ You are a documentation source scanner. Your job is to analyze a single document
 
 **Your Process:**
 
+## Step 0: Check for navigation structure
+
+**Pre-check:** Source root must be accessible.
+
+Run: `python3 ${PLUGIN_ROOT}/lib/corpus/scripts/detect_nav.py --source-root {source_root}`
+
+**Decision logic:**
+- If script fails (exit != 0): DISPLAY warning, fall through to Step 1 (file discovery)
+- If `found: false`: Fall through to Step 1
+- If `coverage_pct >= 80`: Use nav hierarchy as entry skeleton. Set `computed.nav_skeleton`. DISPLAY coverage info. Files not in nav are still scanned in Step 1.
+- If `coverage_pct` between 50-80: ASK user whether to use nav skeleton or fall back to full scanning.
+- If `coverage_pct < 50`: DISPLAY low coverage, fall through to Step 1.
+
 1. **Verify source availability**
    - Git: Check `.source/{source_id}/` exists or report missing
    - Local: Check `data/uploads/{source_id}/` exists
@@ -46,6 +59,20 @@ You are a documentation source scanner. Your job is to analyze a single document
    - Count total files (.md, .mdx)
    - Use Glob to find all markdown files efficiently
    - Calculate total file count
+
+## Step 1b: Detect and split large files
+
+**Pre-check:** `computed.file_list` must exist and be non-empty. Skip if `config.build.large_file_threshold == 0`.
+
+Run: `python3 ${PLUGIN_ROOT}/lib/corpus/scripts/detect_large_files.py --source-root {source_root} --max-tokens {threshold}`
+
+For each large file with `has_headings: true`:
+  Run: `python3 ${PLUGIN_ROOT}/lib/corpus/scripts/split_by_headings.py --file {path} --min-tokens 200 --json`
+  Generate parent entry + child section entries from split result.
+
+For large files without headings: Use existing `size: large` + `grep_hint` fallback.
+
+**Post-check:** DISPLAY summary: "{N} large files detected, {M} sub-entries generated, {K} using GREP fallback."
 
 3. **Identify top-level sections/directories**
    - List immediate subdirectories in the docs root
@@ -180,6 +207,10 @@ Report this in the top-level scan output so the build skill can make informed re
 ### Chunk Generation
 
 When the caller includes `chunking_config:` in your input (sourced from the source's `chunking:` block in config.yaml), generate chunks for each file.
+
+**Strategy selection:** If `source.chunking.strategy` is not set or is "auto":
+- If `computed.nav_skeleton` exists OR `computed.heading_consistency == "high"`: use `headings` strategy
+- Otherwise: use `markdown` strategy (existing default)
 
 **When chunking is enabled:**
 

--- a/docs/superpowers/plans/2026-04-10-pageindex-build-enhancements.md
+++ b/docs/superpowers/plans/2026-04-10-pageindex-build-enhancements.md
@@ -1,0 +1,2290 @@
+# PageIndex-Inspired Build Enhancements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add five deterministic Python scripts (nav detection, entry verification, tree thinning, large-file splitting, heading-aware chunking) and integrate them into the source-scanner agent and build/refresh skills with proper guard/skip/post-check blocks.
+
+**Architecture:** Six new scripts in `lib/corpus/scripts/` following existing conventions (shebang, docstring, argparse, JSON stdout, exit codes). A shared token-counting utility extracted for DRY. Skill/agent prompt updates add GUARD blocks and post-step summaries matching the existing pseudocode patterns. No index.yaml schema changes. No new required dependencies.
+
+**Tech Stack:** Python 3 stdlib, PyYAML (optional), fastembed (optional for token counting), pytest for tests.
+
+**Spec:** `docs/superpowers/specs/2026-04-10-pageindex-build-enhancements-design.md`
+
+---
+
+## File Structure
+
+### New files
+
+| File | Responsibility |
+|---|---|
+| `lib/corpus/scripts/token_utils.py` | Shared token counting: fastembed tokenizer with word-count fallback |
+| `lib/corpus/scripts/detect_nav.py` | Parse mkdocs.yml / _sidebar.md / SUMMARY.md into hierarchy JSON |
+| `lib/corpus/scripts/verify_entries.py` | Extract content previews for index entries (data prep for LLM verification) |
+| `lib/corpus/scripts/thin_sections.py` | Bottom-up merge of small section entries in index.yaml |
+| `lib/corpus/scripts/detect_large_files.py` | Find markdown files exceeding a token threshold |
+| `lib/corpus/scripts/split_by_headings.py` | Split a markdown file into sections by heading structure |
+| `lib/corpus/scripts/tests/test_detect_nav.py` | Tests for detect_nav.py |
+| `lib/corpus/scripts/tests/test_verify_entries.py` | Tests for verify_entries.py |
+| `lib/corpus/scripts/tests/test_thin_sections.py` | Tests for thin_sections.py |
+| `lib/corpus/scripts/tests/test_detect_large_files.py` | Tests for detect_large_files.py |
+| `lib/corpus/scripts/tests/test_split_by_headings.py` | Tests for split_by_headings.py |
+| `lib/corpus/scripts/tests/test_chunk_headings.py` | Tests for chunk.py headings strategy |
+| `lib/corpus/scripts/tests/test_token_utils.py` | Tests for token_utils.py |
+
+### Modified files
+
+| File | Change |
+|---|---|
+| `lib/corpus/scripts/chunk.py` | Add `headings` strategy option |
+| `agents/source-scanner.md` | Add Step 0 (nav detection), Step 1b (large file splitting), chunking strategy selection |
+| `skills/hiivmind-corpus-build/SKILL.md` | Add tree thinning guard, verification guard (Phase 7c) |
+| `skills/hiivmind-corpus-refresh/SKILL.md` | Add optional post-refresh verification |
+| `lib/corpus/scripts/embed.py` | Prepend `heading_context` to chunk embedding text when present |
+| `CLAUDE.md` | Add cross-cutting concerns rows for five new features |
+
+---
+
+## Task 1: Shared Token Counting Utility
+
+**Files:**
+- Create: `lib/corpus/scripts/token_utils.py`
+- Create: `lib/corpus/scripts/tests/test_token_utils.py`
+
+All five algorithms need token counting. Currently `chunk.py` uses `TOKENS_PER_WORD = 1.3` inline. Extract this into a shared module that tries fastembed's tokenizer first, falls back to word count.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# lib/corpus/scripts/tests/test_token_utils.py
+"""Tests for token_utils.py — shared token counting."""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from token_utils import estimate_tokens
+
+
+class TestEstimateTokens:
+    """Token estimation with graceful fallback."""
+
+    def test_empty_string_returns_zero(self):
+        assert estimate_tokens("") == 0
+
+    def test_single_word(self):
+        result = estimate_tokens("hello")
+        assert result >= 1
+
+    def test_approximation_scales_with_length(self):
+        short = estimate_tokens("one two three")
+        long = estimate_tokens("one two three four five six seven eight nine ten")
+        assert long > short
+
+    def test_none_returns_zero(self):
+        assert estimate_tokens(None) == 0
+
+    def test_whitespace_only_returns_zero(self):
+        assert estimate_tokens("   \n\t  ") == 0
+
+    def test_returns_integer(self):
+        result = estimate_tokens("some words here for testing purposes")
+        assert isinstance(result, int)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /home/nathanielramm/git/hiivmind/hiivmind-corpus && python3 -m pytest lib/corpus/scripts/tests/test_token_utils.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'token_utils'`
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# lib/corpus/scripts/token_utils.py
+#!/usr/bin/env python3
+"""Shared token counting with graceful fallback.
+
+Tries fastembed's tokenizer first (accurate), falls back to
+word-count approximation (len(text.split()) * 1.3).
+
+Usage as module:
+  from token_utils import estimate_tokens
+  count = estimate_tokens("some text here")
+"""
+
+TOKENS_PER_WORD = 1.3
+
+_tokenizer = None
+_tokenizer_checked = False
+
+
+def _get_tokenizer():
+    """Try to load fastembed tokenizer once, cache result."""
+    global _tokenizer, _tokenizer_checked
+    if _tokenizer_checked:
+        return _tokenizer
+    _tokenizer_checked = True
+    try:
+        from fastembed import TextEmbedding
+
+        model = TextEmbedding("BAAI/bge-small-en-v1.5")
+        _tokenizer = model.model.tokenizer
+    except Exception:
+        _tokenizer = None
+    return _tokenizer
+
+
+def estimate_tokens(text: str | None) -> int:
+    """Estimate token count for text.
+
+    Returns 0 for None, empty, or whitespace-only strings.
+    Uses fastembed tokenizer if available, else word-count * 1.3.
+    """
+    if not text or not text.strip():
+        return 0
+
+    tokenizer = _get_tokenizer()
+    if tokenizer is not None:
+        try:
+            return len(tokenizer.encode(text).ids)
+        except Exception:
+            pass
+
+    return int(len(text.split()) * TOKENS_PER_WORD)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /home/nathanielramm/git/hiivmind/hiivmind-corpus && python3 -m pytest lib/corpus/scripts/tests/test_token_utils.py -v`
+Expected: 6 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/corpus/scripts/token_utils.py lib/corpus/scripts/tests/test_token_utils.py
+git commit -m "feat: add shared token counting utility (token_utils.py)"
+```
+
+---
+
+## Task 2: detect_nav.py — Navigation Structure Detection
+
+**Files:**
+- Create: `lib/corpus/scripts/detect_nav.py`
+- Create: `lib/corpus/scripts/tests/test_detect_nav.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# lib/corpus/scripts/tests/test_detect_nav.py
+"""Tests for detect_nav.py — navigation structure detection.
+
+Unit tests (no external deps):
+  - MkDocs YAML nav parsing
+  - Docsify _sidebar.md parsing
+  - mdBook SUMMARY.md parsing
+  - Coverage calculation
+  - Missing files handling
+  - No nav file found
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from detect_nav import detect_nav, parse_mkdocs_nav, parse_sidebar_md
+
+
+class TestParseMkdocsNav:
+    """Parse mkdocs.yml nav: key into hierarchy."""
+
+    def test_simple_flat_nav(self, tmp_path):
+        mkdocs = tmp_path / "mkdocs.yml"
+        mkdocs.write_text(
+            "nav:\n"
+            "  - Home: index.md\n"
+            "  - Getting Started: getting-started.md\n"
+            "  - API Reference: api.md\n"
+        )
+        # Create the referenced files
+        for name in ["index.md", "getting-started.md", "api.md"]:
+            (tmp_path / name).write_text(f"# {name}")
+
+        result = parse_mkdocs_nav(mkdocs, tmp_path)
+        assert len(result) == 3
+        assert result[0]["title"] == "Home"
+        assert result[0]["path"] == "index.md"
+        assert result[0]["level"] == 1
+
+    def test_nested_nav(self, tmp_path):
+        mkdocs = tmp_path / "mkdocs.yml"
+        mkdocs.write_text(
+            "nav:\n"
+            "  - Home: index.md\n"
+            "  - Guide:\n"
+            "    - Install: guide/install.md\n"
+            "    - Usage: guide/usage.md\n"
+        )
+        (tmp_path / "index.md").write_text("# Home")
+        (tmp_path / "guide").mkdir()
+        (tmp_path / "guide" / "install.md").write_text("# Install")
+        (tmp_path / "guide" / "usage.md").write_text("# Usage")
+
+        result = parse_mkdocs_nav(mkdocs, tmp_path)
+        assert len(result) == 2  # Home + Guide (with children)
+        guide = result[1]
+        assert guide["title"] == "Guide"
+        assert len(guide["children"]) == 2
+        assert guide["children"][0]["level"] == 2
+
+    def test_missing_files_still_parsed(self, tmp_path):
+        mkdocs = tmp_path / "mkdocs.yml"
+        mkdocs.write_text(
+            "nav:\n"
+            "  - Exists: exists.md\n"
+            "  - Missing: missing.md\n"
+        )
+        (tmp_path / "exists.md").write_text("# Exists")
+        # missing.md intentionally not created
+
+        result = parse_mkdocs_nav(mkdocs, tmp_path)
+        assert len(result) == 2  # both parsed
+
+
+class TestParseSidebarMd:
+    """Parse _sidebar.md / SUMMARY.md link-list format."""
+
+    def test_flat_sidebar(self, tmp_path):
+        sidebar = tmp_path / "_sidebar.md"
+        sidebar.write_text(
+            "- [Home](index.md)\n"
+            "- [Guide](guide.md)\n"
+            "- [API](api.md)\n"
+        )
+        for name in ["index.md", "guide.md", "api.md"]:
+            (tmp_path / name).write_text(f"# {name}")
+
+        result = parse_sidebar_md(sidebar, tmp_path)
+        assert len(result) == 3
+        assert result[0]["title"] == "Home"
+        assert result[0]["path"] == "index.md"
+
+    def test_nested_sidebar(self, tmp_path):
+        sidebar = tmp_path / "SUMMARY.md"
+        sidebar.write_text(
+            "- [Introduction](intro.md)\n"
+            "  - [Install](install.md)\n"
+            "  - [Config](config.md)\n"
+            "- [Advanced](advanced.md)\n"
+        )
+        for name in ["intro.md", "install.md", "config.md", "advanced.md"]:
+            (tmp_path / name).write_text(f"# {name}")
+
+        result = parse_sidebar_md(sidebar, tmp_path)
+        assert len(result) == 2  # Introduction (with children) + Advanced
+        assert len(result[0]["children"]) == 2
+        assert result[0]["children"][0]["level"] == 2
+
+
+class TestDetectNav:
+    """End-to-end nav detection."""
+
+    def test_no_nav_file(self, tmp_path):
+        (tmp_path / "readme.md").write_text("# Hello")
+        result = detect_nav(str(tmp_path))
+        assert result["found"] is False
+        assert result["hierarchy"] == []
+
+    def test_mkdocs_detected(self, tmp_path):
+        mkdocs = tmp_path / "mkdocs.yml"
+        mkdocs.write_text(
+            "site_name: Test\n"
+            "nav:\n"
+            "  - Home: index.md\n"
+            "  - About: about.md\n"
+        )
+        (tmp_path / "index.md").write_text("# Home")
+        (tmp_path / "about.md").write_text("# About")
+
+        result = detect_nav(str(tmp_path))
+        assert result["found"] is True
+        assert result["nav_file"] == "mkdocs.yml"
+        assert result["framework"] == "mkdocs"
+        assert len(result["hierarchy"]) == 2
+
+    def test_coverage_calculation(self, tmp_path):
+        mkdocs = tmp_path / "mkdocs.yml"
+        mkdocs.write_text(
+            "nav:\n"
+            "  - Home: index.md\n"
+            "  - Missing: missing.md\n"
+        )
+        (tmp_path / "index.md").write_text("# Home")
+        (tmp_path / "extra.md").write_text("# Extra")
+        # missing.md not created, extra.md not in nav
+
+        result = detect_nav(str(tmp_path))
+        assert result["coverage"]["nav_entries"] == 2
+        assert result["coverage"]["files_resolved"] == 1
+        assert result["coverage"]["files_missing"] == 1
+        assert result["coverage"]["total_md_files"] == 2  # index.md + extra.md
+        assert result["coverage"]["coverage_pct"] == 50.0
+
+    def test_sidebar_fallback(self, tmp_path):
+        sidebar = tmp_path / "_sidebar.md"
+        sidebar.write_text("- [Home](index.md)\n")
+        (tmp_path / "index.md").write_text("# Home")
+
+        result = detect_nav(str(tmp_path))
+        assert result["found"] is True
+        assert result["framework"] == "docsify"
+
+    def test_summary_md_detected(self, tmp_path):
+        summary = tmp_path / "SUMMARY.md"
+        summary.write_text("- [Intro](intro.md)\n")
+        (tmp_path / "intro.md").write_text("# Intro")
+
+        result = detect_nav(str(tmp_path))
+        assert result["found"] is True
+        assert result["framework"] in ("mdbook", "gitbook")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /home/nathanielramm/git/hiivmind/hiivmind-corpus && python3 -m pytest lib/corpus/scripts/tests/test_detect_nav.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'detect_nav'`
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# lib/corpus/scripts/detect_nav.py
+#!/usr/bin/env python3
+"""Detect and parse documentation navigation structure.
+
+Usage:
+  python3 detect_nav.py --source-root <path>
+
+Scans for mkdocs.yml, _sidebar.md, SUMMARY.md, _toc.yml in priority order.
+Parses the first found into a hierarchy with coverage stats.
+
+Output: JSON to stdout with {found, nav_file, framework, hierarchy, coverage}.
+
+Exit codes:
+  0 - success (found or not found)
+  1 - invalid arguments
+  2 - python error
+"""
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# Priority-ordered nav file candidates: (filename, framework, parser)
+NAV_CANDIDATES = [
+    ("mkdocs.yml", "mkdocs", "yaml_nav"),
+    ("mkdocs.yaml", "mkdocs", "yaml_nav"),
+    ("_sidebar.md", "docsify", "sidebar_md"),
+    ("SUMMARY.md", "mdbook", "sidebar_md"),
+    ("src/SUMMARY.md", "mdbook", "sidebar_md"),
+    ("_toc.yml", "custom", "yaml_toc"),
+]
+
+LINK_RE = re.compile(r"^(\s*)-\s*\[([^\]]+)\]\(([^)]+)\)")
+
+
+def parse_mkdocs_nav(nav_file: Path, source_root: Path) -> list[dict]:
+    """Parse mkdocs.yml nav: key into hierarchy list."""
+    try:
+        import yaml
+    except ImportError:
+        return _parse_mkdocs_nav_regex(nav_file, source_root)
+
+    with open(nav_file) as f:
+        data = yaml.safe_load(f)
+
+    nav = data.get("nav") if isinstance(data, dict) else None
+    if not nav:
+        return []
+
+    return _walk_mkdocs_nav(nav, source_root, level=1)
+
+
+def _walk_mkdocs_nav(nav_items: list, source_root: Path, level: int) -> list[dict]:
+    """Recursively walk mkdocs nav structure."""
+    result = []
+    for item in nav_items:
+        if isinstance(item, dict):
+            for title, value in item.items():
+                if isinstance(value, str):
+                    # Leaf: "Title: path.md"
+                    result.append({
+                        "title": title,
+                        "path": value,
+                        "level": level,
+                        "children": [],
+                    })
+                elif isinstance(value, list):
+                    # Group: "Title: [children]"
+                    children = _walk_mkdocs_nav(value, source_root, level + 1)
+                    result.append({
+                        "title": title,
+                        "path": None,
+                        "level": level,
+                        "children": children,
+                    })
+        elif isinstance(item, str):
+            result.append({
+                "title": item,
+                "path": item,
+                "level": level,
+                "children": [],
+            })
+    return result
+
+
+def _parse_mkdocs_nav_regex(nav_file: Path, source_root: Path) -> list[dict]:
+    """Fallback: extract nav entries from mkdocs.yml via regex (no PyYAML)."""
+    text = nav_file.read_text()
+    # Simple pattern: "  - Title: path.md" lines under nav:
+    in_nav = False
+    result = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("nav:"):
+            in_nav = True
+            continue
+        if in_nav:
+            if not line.startswith(" ") and not line.startswith("\t") and stripped:
+                break  # left nav block
+            match = re.match(r"\s*-\s+(.+?):\s+(\S+\.md\S*)", line)
+            if match:
+                result.append({
+                    "title": match.group(1).strip(),
+                    "path": match.group(2).strip(),
+                    "level": 1,
+                    "children": [],
+                })
+    return result
+
+
+def parse_sidebar_md(sidebar_file: Path, source_root: Path) -> list[dict]:
+    """Parse _sidebar.md or SUMMARY.md link-list format into hierarchy."""
+    text = sidebar_file.read_text()
+    flat = []
+    for line in text.splitlines():
+        match = LINK_RE.match(line)
+        if match:
+            indent = len(match.group(1))
+            level = (indent // 2) + 1
+            flat.append({
+                "title": match.group(2).strip(),
+                "path": match.group(3).strip(),
+                "level": level,
+                "children": [],
+            })
+
+    # Build nested structure from flat list using level
+    return _nest_by_level(flat)
+
+
+def _nest_by_level(flat: list[dict]) -> list[dict]:
+    """Convert flat list with levels into nested children."""
+    if not flat:
+        return []
+
+    root = []
+    stack: list[dict] = []
+
+    for item in flat:
+        while stack and stack[-1]["level"] >= item["level"]:
+            stack.pop()
+
+        if stack:
+            stack[-1]["children"].append(item)
+        else:
+            root.append(item)
+
+        stack.append(item)
+
+    return root
+
+
+def _collect_paths(hierarchy: list[dict]) -> list[str]:
+    """Collect all paths from hierarchy (recursive)."""
+    paths = []
+    for item in hierarchy:
+        if item.get("path"):
+            paths.append(item["path"])
+        paths.extend(_collect_paths(item.get("children", [])))
+    return paths
+
+
+def _count_md_files(source_root: Path) -> int:
+    """Count all .md/.mdx files in source root."""
+    count = 0
+    for ext in ("*.md", "*.mdx"):
+        count += len(list(source_root.rglob(ext)))
+    return count
+
+
+def detect_nav(source_root_str: str) -> dict:
+    """Detect navigation structure in a source root directory.
+
+    Returns dict with found, nav_file, framework, hierarchy, coverage.
+    """
+    source_root = Path(source_root_str)
+    empty_result = {
+        "found": False,
+        "nav_file": None,
+        "framework": None,
+        "hierarchy": [],
+        "coverage": {
+            "nav_entries": 0,
+            "files_resolved": 0,
+            "files_missing": 0,
+            "total_md_files": _count_md_files(source_root),
+            "coverage_pct": 0.0,
+        },
+    }
+
+    if not source_root.is_dir():
+        return empty_result
+
+    # Try each nav file candidate in priority order
+    for filename, framework, parser_type in NAV_CANDIDATES:
+        nav_path = source_root / filename
+        if not nav_path.exists():
+            continue
+
+        if parser_type == "yaml_nav":
+            hierarchy = parse_mkdocs_nav(nav_path, source_root)
+        elif parser_type == "sidebar_md":
+            hierarchy = parse_sidebar_md(nav_path, source_root)
+        elif parser_type == "yaml_toc":
+            hierarchy = parse_mkdocs_nav(nav_path, source_root)  # similar structure
+        else:
+            continue
+
+        if not hierarchy:
+            continue
+
+        # Calculate coverage
+        all_paths = _collect_paths(hierarchy)
+        resolved = sum(1 for p in all_paths if (source_root / p).exists())
+        missing = len(all_paths) - resolved
+        total_md = _count_md_files(source_root)
+        coverage_pct = round((resolved / total_md * 100) if total_md > 0 else 0.0, 1)
+
+        return {
+            "found": True,
+            "nav_file": filename,
+            "framework": framework,
+            "hierarchy": hierarchy,
+            "coverage": {
+                "nav_entries": len(all_paths),
+                "files_resolved": resolved,
+                "files_missing": missing,
+                "total_md_files": total_md,
+                "coverage_pct": coverage_pct,
+            },
+        }
+
+    return empty_result
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Detect documentation nav structure")
+    parser.add_argument("--source-root", required=True, help="Path to source root directory")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    result = detect_nav(args.source_root)
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception as e:
+        print(f"error: {e}", file=sys.stderr)
+        sys.exit(2)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /home/nathanielramm/git/hiivmind/hiivmind-corpus && python3 -m pytest lib/corpus/scripts/tests/test_detect_nav.py -v`
+Expected: All 10 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/corpus/scripts/detect_nav.py lib/corpus/scripts/tests/test_detect_nav.py
+git commit -m "feat: add navigation structure detection (detect_nav.py)"
+```
+
+---
+
+## Task 3: verify_entries.py — Entry Content Verification
+
+**Files:**
+- Create: `lib/corpus/scripts/verify_entries.py`
+- Create: `lib/corpus/scripts/tests/test_verify_entries.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# lib/corpus/scripts/tests/test_verify_entries.py
+"""Tests for verify_entries.py — entry content verification data prep.
+
+Unit tests (no external deps):
+  - Extracts content preview from existing files
+  - Handles missing files gracefully
+  - Respects token limit
+  - Samples entries when --sample is set
+  - Filters by --entries when set
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from verify_entries import extract_previews
+
+
+@pytest.fixture
+def sample_index(tmp_path):
+    """Create a minimal index.yaml and source files."""
+    index_yaml = tmp_path / "index.yaml"
+    index_yaml.write_text(
+        "meta:\n"
+        "  entry_count: 3\n"
+        "entries:\n"
+        "  - id: 'src:docs/intro.md'\n"
+        "    title: Introduction\n"
+        "    summary: Overview of the project\n"
+        "    source: docs/intro.md\n"
+        "  - id: 'src:docs/guide.md'\n"
+        "    title: Guide\n"
+        "    summary: How to use the tool\n"
+        "    source: docs/guide.md\n"
+        "  - id: 'src:docs/missing.md'\n"
+        "    title: Missing\n"
+        "    summary: This file does not exist\n"
+        "    source: docs/missing.md\n"
+    )
+    source_root = tmp_path / "source"
+    docs = source_root / "docs"
+    docs.mkdir(parents=True)
+    (docs / "intro.md").write_text("# Introduction\n\nThis is the overview of the project.\n" * 10)
+    (docs / "guide.md").write_text("# Guide\n\nStep by step instructions.\n" * 5)
+    # missing.md intentionally not created
+    return index_yaml, source_root
+
+
+class TestExtractPreviews:
+    def test_extracts_existing_files(self, sample_index):
+        index_yaml, source_root = sample_index
+        result = extract_previews(str(index_yaml), str(source_root), token_limit=500)
+        existing = [r for r in result if r["content_preview"] is not None]
+        assert len(existing) == 2
+        assert existing[0]["entry_id"] == "src:docs/intro.md"
+        assert "Introduction" in existing[0]["content_preview"]
+
+    def test_handles_missing_files(self, sample_index):
+        index_yaml, source_root = sample_index
+        result = extract_previews(str(index_yaml), str(source_root), token_limit=500)
+        missing = [r for r in result if r["content_preview"] is None]
+        assert len(missing) == 1
+        assert missing[0]["entry_id"] == "src:docs/missing.md"
+
+    def test_respects_token_limit(self, sample_index):
+        index_yaml, source_root = sample_index
+        result = extract_previews(str(index_yaml), str(source_root), token_limit=10)
+        for r in result:
+            if r["content_preview"] is not None:
+                word_count = len(r["content_preview"].split())
+                assert word_count <= 30  # ~10 tokens * 1.3 safety margin
+
+    def test_sample_limits_count(self, sample_index):
+        index_yaml, source_root = sample_index
+        result = extract_previews(str(index_yaml), str(source_root), token_limit=500, sample=1)
+        assert len(result) == 1
+
+    def test_filter_by_entry_ids(self, sample_index):
+        index_yaml, source_root = sample_index
+        result = extract_previews(
+            str(index_yaml), str(source_root), token_limit=500,
+            entry_ids=["src:docs/guide.md"]
+        )
+        assert len(result) == 1
+        assert result[0]["entry_id"] == "src:docs/guide.md"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /home/nathanielramm/git/hiivmind/hiivmind-corpus && python3 -m pytest lib/corpus/scripts/tests/test_verify_entries.py -v`
+Expected: FAIL — `ModuleNotFoundError`
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# lib/corpus/scripts/verify_entries.py
+#!/usr/bin/env python3
+"""Extract content previews for index entries (data prep for LLM verification).
+
+Usage:
+  python3 verify_entries.py --index <path> --source-root <path> [--token-limit 500] [--sample N] [--entries ID,ID,...]
+
+Output: JSON array to stdout. Each entry has {entry_id, title, summary, source_path, content_preview, token_count}.
+content_preview is null if the source file is missing.
+
+Exit codes:
+  0 - success
+  1 - invalid arguments or missing index
+  2 - python error
+"""
+import argparse
+import json
+import random
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from token_utils import estimate_tokens
+
+
+def _load_index(index_path: str) -> list[dict]:
+    """Load entries from index.yaml."""
+    try:
+        import yaml
+    except ImportError:
+        # Fallback: basic regex extraction
+        return _load_index_regex(index_path)
+
+    with open(index_path) as f:
+        data = yaml.safe_load(f)
+
+    return data.get("entries", []) if isinstance(data, dict) else []
+
+
+def _load_index_regex(index_path: str) -> list[dict]:
+    """Fallback index loader using regex (no PyYAML)."""
+    text = Path(index_path).read_text()
+    entries = []
+    current: dict | None = None
+    for line in text.splitlines():
+        if line.strip().startswith("- id:"):
+            if current:
+                entries.append(current)
+            current = {"id": line.split(":", 1)[1].strip().strip("'\"")}
+        elif current and ":" in line and line.startswith("    "):
+            key, _, val = line.strip().partition(":")
+            current[key.strip()] = val.strip().strip("'\"")
+    if current:
+        entries.append(current)
+    return entries
+
+
+def _truncate_to_tokens(text: str, token_limit: int) -> str:
+    """Truncate text to approximately token_limit tokens."""
+    words = text.split()
+    # Approximate: 1 token ≈ 1 word / 1.3
+    word_limit = int(token_limit / 1.3) + 1
+    if len(words) <= word_limit:
+        return text
+    return " ".join(words[:word_limit])
+
+
+def extract_previews(
+    index_path: str,
+    source_root: str,
+    token_limit: int = 500,
+    sample: int | None = None,
+    entry_ids: list[str] | None = None,
+) -> list[dict]:
+    """Extract content previews for index entries.
+
+    Args:
+        index_path: Path to index.yaml
+        source_root: Path to source root directory
+        token_limit: Max tokens per preview
+        sample: If set, randomly sample this many entries
+        entry_ids: If set, only process these entry IDs
+
+    Returns:
+        List of dicts with entry_id, title, summary, source_path, content_preview, token_count.
+    """
+    entries = _load_index(index_path)
+    source = Path(source_root)
+
+    # Filter by entry IDs if specified
+    if entry_ids:
+        id_set = set(entry_ids)
+        entries = [e for e in entries if e.get("id") in id_set]
+
+    # Sample if specified
+    if sample is not None and sample < len(entries):
+        entries = random.sample(entries, sample)
+
+    result = []
+    for entry in entries:
+        entry_id = entry.get("id", "")
+        title = entry.get("title", "")
+        summary = entry.get("summary", "")
+        source_path = entry.get("source", "")
+
+        # Resolve source path — strip source_id prefix if present
+        # Entry IDs look like "src:docs/intro.md", source field is "docs/intro.md"
+        file_path = source / source_path
+
+        if file_path.exists():
+            content = file_path.read_text(errors="replace")
+            preview = _truncate_to_tokens(content, token_limit)
+            token_count = estimate_tokens(preview)
+        else:
+            preview = None
+            token_count = 0
+
+        result.append({
+            "entry_id": entry_id,
+            "title": title,
+            "summary": summary,
+            "source_path": source_path,
+            "content_preview": preview,
+            "token_count": token_count,
+        })
+
+    return result
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Extract content previews for entry verification")
+    parser.add_argument("--index", required=True, help="Path to index.yaml")
+    parser.add_argument("--source-root", required=True, help="Path to source root directory")
+    parser.add_argument("--token-limit", type=int, default=500, help="Max tokens per preview (default: 500)")
+    parser.add_argument("--sample", type=int, default=None, help="Random sample N entries (default: all)")
+    parser.add_argument("--entries", default=None, help="Comma-separated entry IDs to verify")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    entry_ids = args.entries.split(",") if args.entries else None
+    result = extract_previews(
+        args.index, args.source_root,
+        token_limit=args.token_limit,
+        sample=args.sample,
+        entry_ids=entry_ids,
+    )
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception as e:
+        print(f"error: {e}", file=sys.stderr)
+        sys.exit(2)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /home/nathanielramm/git/hiivmind/hiivmind-corpus && python3 -m pytest lib/corpus/scripts/tests/test_verify_entries.py -v`
+Expected: 5 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/corpus/scripts/verify_entries.py lib/corpus/scripts/tests/test_verify_entries.py
+git commit -m "feat: add entry content verification (verify_entries.py)"
+```
+
+---
+
+## Task 4: split_by_headings.py — Heading-Based File Splitting
+
+**Files:**
+- Create: `lib/corpus/scripts/split_by_headings.py`
+- Create: `lib/corpus/scripts/tests/test_split_by_headings.py`
+
+This is needed by both Algorithm 4 (large-node splitting) and Algorithm 5 (heading-aware chunking), so it comes before both.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# lib/corpus/scripts/tests/test_split_by_headings.py
+"""Tests for split_by_headings.py — heading-based file splitting.
+
+Unit tests (no external deps):
+  - Splits on headings at configured levels
+  - Skips headings inside code blocks
+  - Generates correct anchors
+  - Calculates line ranges
+  - Merges small sections (tree thinning)
+  - Handles files with no headings
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from split_by_headings import split_by_headings
+
+
+class TestSplitByHeadings:
+    def test_basic_split(self):
+        text = (
+            "# Title\n"
+            "\n"
+            "Intro paragraph.\n"
+            "\n"
+            "## Section One\n"
+            "\n"
+            "Content for section one.\n"
+            "More content here.\n"
+            "\n"
+            "## Section Two\n"
+            "\n"
+            "Content for section two.\n"
+        )
+        result = split_by_headings(text, min_level=2, max_level=4, min_tokens=0)
+        assert len(result) == 2
+        assert result[0]["title"] == "Section One"
+        assert result[1]["title"] == "Section Two"
+
+    def test_line_ranges(self):
+        text = (
+            "## First\n"
+            "Line 2\n"
+            "Line 3\n"
+            "\n"
+            "## Second\n"
+            "Line 6\n"
+        )
+        result = split_by_headings(text, min_level=2, max_level=4, min_tokens=0)
+        assert result[0]["line_start"] == 1
+        assert result[0]["line_end"] == 4
+        assert result[1]["line_start"] == 5
+        assert result[1]["line_end"] == 6
+
+    def test_anchor_generation(self):
+        text = (
+            "## Getting Started Guide\n"
+            "Content.\n"
+            "\n"
+            "## API (v2) Reference!\n"
+            "Content.\n"
+        )
+        result = split_by_headings(text, min_level=2, max_level=4, min_tokens=0)
+        assert result[0]["anchor"] == "getting-started-guide"
+        assert result[1]["anchor"] == "api-v2-reference"
+
+    def test_skips_code_block_headings(self):
+        text = (
+            "## Real Heading\n"
+            "Content.\n"
+            "\n"
+            "```markdown\n"
+            "## Fake Heading Inside Code\n"
+            "```\n"
+            "\n"
+            "## Another Real Heading\n"
+            "Content.\n"
+        )
+        result = split_by_headings(text, min_level=2, max_level=4, min_tokens=0)
+        assert len(result) == 2
+        titles = [r["title"] for r in result]
+        assert "Fake Heading Inside Code" not in titles
+
+    def test_respects_level_range(self):
+        text = (
+            "# H1\n"
+            "Content.\n"
+            "## H2\n"
+            "Content.\n"
+            "### H3\n"
+            "Content.\n"
+            "#### H4\n"
+            "Content.\n"
+            "##### H5\n"
+            "Content.\n"
+        )
+        result = split_by_headings(text, min_level=2, max_level=3, min_tokens=0)
+        levels = [r["level"] for r in result]
+        assert all(2 <= l <= 3 for l in levels)
+
+    def test_merges_small_sections(self):
+        text = (
+            "## Big Section\n"
+            + "Word " * 200
+            + "\n\n## Tiny\nOne line.\n\n## Another Big\n"
+            + "Word " * 200
+            + "\n"
+        )
+        result = split_by_headings(text, min_level=2, max_level=4, min_tokens=100)
+        # "Tiny" section should be merged into previous section
+        titles = [r["title"] for r in result]
+        assert "Tiny" not in titles
+
+    def test_no_headings_returns_empty(self):
+        text = "Just a plain text file.\nWith no headings at all.\n"
+        result = split_by_headings(text, min_level=2, max_level=4, min_tokens=0)
+        assert result == []
+
+    def test_text_preview_included(self):
+        text = (
+            "## Section\n"
+            "First line of content.\n"
+            "Second line.\n"
+        )
+        result = split_by_headings(text, min_level=2, max_level=4, min_tokens=0)
+        assert "text_preview" in result[0]
+        assert "First line" in result[0]["text_preview"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /home/nathanielramm/git/hiivmind/hiivmind-corpus && python3 -m pytest lib/corpus/scripts/tests/test_split_by_headings.py -v`
+Expected: FAIL — `ModuleNotFoundError`
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# lib/corpus/scripts/split_by_headings.py
+#!/usr/bin/env python3
+"""Split a markdown file into sections by heading structure.
+
+Usage:
+  python3 split_by_headings.py --file <path> [--min-level 2] [--max-level 4] [--min-tokens 200] [--json]
+
+Output: JSON array of sections with title, level, line_start, line_end, token_count, anchor, text_preview.
+
+Exit codes:
+  0 - success
+  1 - invalid arguments
+  2 - file not found
+  3 - python error
+"""
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from token_utils import estimate_tokens
+
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.+)$")
+CODE_FENCE_RE = re.compile(r"^```")
+ANCHOR_STRIP_RE = re.compile(r"[^\w\s-]")
+
+
+def _make_anchor(title: str) -> str:
+    """Generate URL anchor from heading title."""
+    anchor = title.lower().strip()
+    anchor = ANCHOR_STRIP_RE.sub("", anchor)
+    anchor = re.sub(r"\s+", "-", anchor)
+    anchor = anchor.strip("-")
+    return anchor
+
+
+def split_by_headings(
+    text: str,
+    min_level: int = 2,
+    max_level: int = 4,
+    min_tokens: int = 200,
+) -> list[dict]:
+    """Split markdown text into sections by heading structure.
+
+    Args:
+        text: Markdown content
+        min_level: Minimum heading level to split at (2 = ##)
+        max_level: Maximum heading level to split at (4 = ####)
+        min_tokens: Sections below this token count are merged into previous
+
+    Returns:
+        List of section dicts with title, level, line_start, line_end,
+        token_count, anchor, text_preview.
+    """
+    lines = text.split("\n")
+    in_code_block = False
+    raw_sections = []
+
+    for i, line in enumerate(lines):
+        if CODE_FENCE_RE.match(line.strip()):
+            in_code_block = not in_code_block
+            continue
+
+        if in_code_block:
+            continue
+
+        match = HEADING_RE.match(line)
+        if match:
+            level = len(match.group(1))
+            if min_level <= level <= max_level:
+                title = match.group(2).strip()
+                raw_sections.append({
+                    "title": title,
+                    "level": level,
+                    "line_start": i + 1,  # 1-indexed
+                })
+
+    if not raw_sections:
+        return []
+
+    # Calculate line ranges and token counts
+    for idx, section in enumerate(raw_sections):
+        if idx + 1 < len(raw_sections):
+            section["line_end"] = raw_sections[idx + 1]["line_start"] - 1
+        else:
+            section["line_end"] = len(lines)
+
+        section_text = "\n".join(lines[section["line_start"] - 1 : section["line_end"]])
+        section["token_count"] = estimate_tokens(section_text)
+        section["anchor"] = _make_anchor(section["title"])
+        section["text_preview"] = section_text[:200]
+
+    # Tree thinning: merge small sections into previous
+    if min_tokens > 0:
+        merged = []
+        for section in raw_sections:
+            if section["token_count"] < min_tokens and merged:
+                # Merge into previous section
+                prev = merged[-1]
+                prev["line_end"] = section["line_end"]
+                prev_text = "\n".join(lines[prev["line_start"] - 1 : prev["line_end"]])
+                prev["token_count"] = estimate_tokens(prev_text)
+                prev["text_preview"] = prev_text[:200]
+            else:
+                merged.append(section)
+        raw_sections = merged
+
+    return raw_sections
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Split markdown file by headings")
+    parser.add_argument("--file", required=True, help="Path to markdown file")
+    parser.add_argument("--min-level", type=int, default=2, help="Min heading level (default: 2)")
+    parser.add_argument("--max-level", type=int, default=4, help="Max heading level (default: 4)")
+    parser.add_argument("--min-tokens", type=int, default=200, help="Min tokens per section (default: 200)")
+    parser.add_argument("--json", action="store_true", dest="json_output", help="Output as JSON")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    file_path = Path(args.file)
+    if not file_path.exists():
+        print(f"error: file not found: {args.file}", file=sys.stderr)
+        sys.exit(2)
+
+    text = file_path.read_text(errors="replace")
+    sections = split_by_headings(text, args.min_level, args.max_level, args.min_tokens)
+
+    if args.json_output:
+        print(json.dumps(sections, indent=2))
+    else:
+        for s in sections:
+            print(f"{s['anchor']}\tL{s['line_start']}-{s['line_end']}\t{s['token_count']} tokens\t{s['title']}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception as e:
+        print(f"error: {e}", file=sys.stderr)
+        sys.exit(3)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /home/nathanielramm/git/hiivmind/hiivmind-corpus && python3 -m pytest lib/corpus/scripts/tests/test_split_by_headings.py -v`
+Expected: 8 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/corpus/scripts/split_by_headings.py lib/corpus/scripts/tests/test_split_by_headings.py
+git commit -m "feat: add heading-based file splitting (split_by_headings.py)"
+```
+
+---
+
+## Task 5: detect_large_files.py — Large File Detection
+
+**Files:**
+- Create: `lib/corpus/scripts/detect_large_files.py`
+- Create: `lib/corpus/scripts/tests/test_detect_large_files.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# lib/corpus/scripts/tests/test_detect_large_files.py
+"""Tests for detect_large_files.py — large file detection.
+
+Unit tests (no external deps):
+  - Detects files above token threshold
+  - Ignores files below threshold
+  - Reports heading presence and count
+  - Handles empty directories
+  - Respects --paths filter
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from detect_large_files import detect_large_files
+
+
+@pytest.fixture
+def docs_dir(tmp_path):
+    """Create a directory with files of varying sizes."""
+    # Small file (~10 words)
+    (tmp_path / "small.md").write_text("# Small\n\nJust a small file.\n")
+    # Large file with headings (~200 words)
+    large_content = "# Large File\n\n"
+    for i in range(20):
+        large_content += f"## Section {i}\n\n"
+        large_content += f"Content for section {i}. " * 10 + "\n\n"
+    (tmp_path / "large_with_headings.md").write_text(large_content)
+    # Large file without headings (~200 words)
+    plain_content = "Just a very long file.\n" * 100
+    (tmp_path / "large_plain.md").write_text(plain_content)
+    return tmp_path
+
+
+class TestDetectLargeFiles:
+    def test_detects_large_files(self, docs_dir):
+        result = detect_large_files(str(docs_dir), max_tokens=50)
+        paths = [r["path"] for r in result]
+        assert any("large_with_headings" in p for p in paths)
+        assert any("large_plain" in p for p in paths)
+
+    def test_ignores_small_files(self, docs_dir):
+        result = detect_large_files(str(docs_dir), max_tokens=50)
+        paths = [r["path"] for r in result]
+        assert not any("small" in p for p in paths)
+
+    def test_reports_heading_info(self, docs_dir):
+        result = detect_large_files(str(docs_dir), max_tokens=50)
+        with_headings = [r for r in result if "large_with_headings" in r["path"]]
+        assert len(with_headings) == 1
+        assert with_headings[0]["has_headings"] is True
+        assert with_headings[0]["heading_count"] >= 20
+
+    def test_no_headings_detected(self, docs_dir):
+        result = detect_large_files(str(docs_dir), max_tokens=50)
+        plain = [r for r in result if "large_plain" in r["path"]]
+        assert len(plain) == 1
+        assert plain[0]["has_headings"] is False
+
+    def test_empty_dir(self, tmp_path):
+        result = detect_large_files(str(tmp_path), max_tokens=50)
+        assert result == []
+
+    def test_high_threshold_finds_nothing(self, docs_dir):
+        result = detect_large_files(str(docs_dir), max_tokens=999999)
+        assert result == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /home/nathanielramm/git/hiivmind/hiivmind-corpus && python3 -m pytest lib/corpus/scripts/tests/test_detect_large_files.py -v`
+Expected: FAIL — `ModuleNotFoundError`
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# lib/corpus/scripts/detect_large_files.py
+#!/usr/bin/env python3
+"""Detect markdown files exceeding a token threshold.
+
+Usage:
+  python3 detect_large_files.py --source-root <path> [--max-tokens 15000] [--paths <file>]
+
+Output: JSON array of {path, token_count, line_count, has_headings, heading_count, deepest_heading_level}.
+
+Exit codes:
+  0 - success
+  1 - invalid arguments
+  2 - python error
+"""
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from token_utils import estimate_tokens
+
+HEADING_RE = re.compile(r"^(#{1,6})\s+", re.MULTILINE)
+
+
+def detect_large_files(
+    source_root: str,
+    max_tokens: int = 15000,
+    paths: list[str] | None = None,
+) -> list[dict]:
+    """Find markdown files exceeding max_tokens.
+
+    Args:
+        source_root: Path to source root directory
+        max_tokens: Token threshold for "large"
+        paths: If set, only check these relative paths
+
+    Returns:
+        List of dicts with path, token_count, line_count, has_headings,
+        heading_count, deepest_heading_level.
+    """
+    root = Path(source_root)
+    result = []
+
+    if paths:
+        files = [root / p for p in paths]
+    else:
+        files = sorted(root.rglob("*.md")) + sorted(root.rglob("*.mdx"))
+
+    for file_path in files:
+        if not file_path.exists():
+            continue
+
+        text = file_path.read_text(errors="replace")
+        token_count = estimate_tokens(text)
+
+        if token_count <= max_tokens:
+            continue
+
+        headings = HEADING_RE.findall(text)
+        heading_count = len(headings)
+        deepest = max((len(h) for h in headings), default=0) if headings else 0
+
+        rel_path = str(file_path.relative_to(root))
+        result.append({
+            "path": rel_path,
+            "token_count": token_count,
+            "line_count": text.count("\n") + 1,
+            "has_headings": heading_count > 0,
+            "heading_count": heading_count,
+            "deepest_heading_level": deepest,
+        })
+
+    return result
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Detect large markdown files")
+    parser.add_argument("--source-root", required=True, help="Path to source root")
+    parser.add_argument("--max-tokens", type=int, default=15000, help="Token threshold (default: 15000)")
+    parser.add_argument("--paths", default=None, help="File with paths to check (one per line)")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    paths = None
+    if args.paths:
+        paths = Path(args.paths).read_text().strip().splitlines()
+
+    result = detect_large_files(args.source_root, args.max_tokens, paths)
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception as e:
+        print(f"error: {e}", file=sys.stderr)
+        sys.exit(2)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /home/nathanielramm/git/hiivmind/hiivmind-corpus && python3 -m pytest lib/corpus/scripts/tests/test_detect_large_files.py -v`
+Expected: 6 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/corpus/scripts/detect_large_files.py lib/corpus/scripts/tests/test_detect_large_files.py
+git commit -m "feat: add large file detection (detect_large_files.py)"
+```
+
+---
+
+## Task 6: thin_sections.py — Section Tree Thinning
+
+**Files:**
+- Create: `lib/corpus/scripts/thin_sections.py`
+- Create: `lib/corpus/scripts/tests/test_thin_sections.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# lib/corpus/scripts/tests/test_thin_sections.py
+"""Tests for thin_sections.py — bottom-up section merging.
+
+Unit tests (no external deps):
+  - Merges small sections into siblings
+  - Merges into parent when no sibling
+  - Never merges across source files
+  - Never merges sections with children
+  - Preserves keywords from merged sections
+  - Dry-run mode does not modify
+  - Updates entry count
+"""
+import copy
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from thin_sections import thin_sections
+
+
+def _make_index(entries):
+    """Helper: wrap entries in index.yaml structure."""
+    return {"meta": {"entry_count": len(entries)}, "entries": entries}
+
+
+class TestThinSections:
+    def test_merges_small_into_sibling(self):
+        index = _make_index([
+            {"id": "src:api.md", "title": "API", "summary": "API docs", "tier": "file"},
+            {"id": "src:api.md#methods", "title": "Methods", "summary": "Method docs " * 30,
+             "tier": "section", "parent": "src:api.md", "heading_level": 2,
+             "line_range": [10, 50], "keywords": ["methods"]},
+            {"id": "src:api.md#params", "title": "Parameters", "summary": "Short",
+             "tier": "section", "parent": "src:api.md", "heading_level": 2,
+             "line_range": [51, 55], "keywords": ["params"]},
+        ])
+        result = thin_sections(index, min_tokens=100)
+        section_ids = [e["id"] for e in result["entries"] if e.get("tier") == "section"]
+        assert "src:api.md#params" not in section_ids
+        # Keywords preserved on the surviving sibling
+        methods = [e for e in result["entries"] if e["id"] == "src:api.md#methods"][0]
+        assert "params" in methods["keywords"]
+
+    def test_merges_into_parent_when_no_sibling(self):
+        index = _make_index([
+            {"id": "src:api.md", "title": "API", "summary": "API docs",
+             "tier": "file", "keywords": ["api"]},
+            {"id": "src:api.md#tiny", "title": "Tiny", "summary": "Short",
+             "tier": "section", "parent": "src:api.md", "heading_level": 2,
+             "line_range": [10, 12], "keywords": ["tiny"]},
+        ])
+        result = thin_sections(index, min_tokens=100)
+        section_ids = [e["id"] for e in result["entries"] if e.get("tier") == "section"]
+        assert "src:api.md#tiny" not in section_ids
+        parent = [e for e in result["entries"] if e["id"] == "src:api.md"][0]
+        assert "tiny" in parent["keywords"]
+
+    def test_never_merges_across_sources(self):
+        index = _make_index([
+            {"id": "src1:a.md", "title": "A", "summary": "A docs", "tier": "file"},
+            {"id": "src1:a.md#small", "title": "Small A", "summary": "Short",
+             "tier": "section", "parent": "src1:a.md", "heading_level": 2,
+             "line_range": [1, 3], "keywords": []},
+            {"id": "src2:b.md", "title": "B", "summary": "B docs " * 30, "tier": "file"},
+            {"id": "src2:b.md#big", "title": "Big B", "summary": "Big section " * 30,
+             "tier": "section", "parent": "src2:b.md", "heading_level": 2,
+             "line_range": [1, 50], "keywords": []},
+        ])
+        result = thin_sections(index, min_tokens=100)
+        # src1 small section can only merge into src1 parent, not into src2
+        section_ids = [e["id"] for e in result["entries"] if e.get("tier") == "section"]
+        assert "src1:a.md#small" not in section_ids
+
+    def test_never_merges_section_with_children(self):
+        index = _make_index([
+            {"id": "src:api.md", "title": "API", "summary": "API docs", "tier": "file"},
+            {"id": "src:api.md#parent", "title": "Parent", "summary": "Short",
+             "tier": "section", "parent": "src:api.md", "heading_level": 2,
+             "line_range": [10, 50], "keywords": []},
+            {"id": "src:api.md#child", "title": "Child", "summary": "Child section " * 30,
+             "tier": "section", "parent": "src:api.md#parent", "heading_level": 3,
+             "line_range": [20, 50], "keywords": []},
+        ])
+        result = thin_sections(index, min_tokens=100)
+        # Parent has children, so it must not be merged even if small
+        section_ids = [e["id"] for e in result["entries"] if e.get("tier") == "section"]
+        assert "src:api.md#parent" in section_ids
+
+    def test_updates_entry_count(self):
+        index = _make_index([
+            {"id": "src:api.md", "title": "API", "summary": "API docs", "tier": "file"},
+            {"id": "src:api.md#big", "title": "Big", "summary": "Big section " * 30,
+             "tier": "section", "parent": "src:api.md", "heading_level": 2,
+             "line_range": [10, 50], "keywords": []},
+            {"id": "src:api.md#tiny", "title": "Tiny", "summary": "Short",
+             "tier": "section", "parent": "src:api.md", "heading_level": 2,
+             "line_range": [51, 53], "keywords": []},
+        ])
+        result = thin_sections(index, min_tokens=100)
+        assert result["meta"]["entry_count"] == len(result["entries"])
+
+    def test_dry_run_returns_plan(self):
+        index = _make_index([
+            {"id": "src:api.md", "title": "API", "summary": "API docs", "tier": "file"},
+            {"id": "src:api.md#tiny", "title": "Tiny", "summary": "Short",
+             "tier": "section", "parent": "src:api.md", "heading_level": 2,
+             "line_range": [1, 3], "keywords": []},
+        ])
+        original = copy.deepcopy(index)
+        result = thin_sections(index, min_tokens=100, dry_run=True)
+        # In dry_run, the input should not be modified
+        assert index == original
+        # But the result should report what would be merged
+        assert result["sections_before"] >= 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /home/nathanielramm/git/hiivmind/hiivmind-corpus && python3 -m pytest lib/corpus/scripts/tests/test_thin_sections.py -v`
+Expected: FAIL — `ModuleNotFoundError`
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# lib/corpus/scripts/thin_sections.py
+#!/usr/bin/env python3
+"""Bottom-up merge of small section entries in index.yaml.
+
+Usage:
+  python3 thin_sections.py --index <path> [--min-tokens 300] [--dry-run]
+
+Merges section entries below min-tokens into their nearest sibling or parent.
+Modifies index.yaml in-place unless --dry-run.
+
+Output: JSON summary to stdout with sections_before, sections_after, merged[].
+
+Exit codes:
+  0 - success
+  1 - invalid arguments or missing index
+  2 - python error
+"""
+import argparse
+import copy
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from token_utils import estimate_tokens
+
+
+def _has_children(entry_id: str, entries: list[dict]) -> bool:
+    """Check if any entry has this entry_id as parent."""
+    return any(e.get("parent") == entry_id for e in entries)
+
+
+def _source_prefix(entry_id: str) -> str:
+    """Extract source prefix from entry ID (everything before the first colon+path)."""
+    if ":" in entry_id:
+        return entry_id.split(":")[0]
+    return ""
+
+
+def thin_sections(
+    index: dict,
+    min_tokens: int = 300,
+    dry_run: bool = False,
+) -> dict:
+    """Merge small section entries bottom-up.
+
+    Args:
+        index: Parsed index.yaml dict with meta and entries keys
+        min_tokens: Sections below this token count are merged
+        dry_run: If True, return merge plan without modifying index
+
+    Returns:
+        If dry_run: dict with sections_before, sections_after, merged[]
+        If not dry_run: modified index dict
+    """
+    if dry_run:
+        work = copy.deepcopy(index)
+    else:
+        work = index
+
+    entries = work.get("entries", [])
+    sections = [e for e in entries if e.get("tier") == "section"]
+    sections_before = len(sections)
+    merged_log = []
+
+    # Sort sections by heading_level descending (deepest first = bottom-up)
+    sections_by_depth = sorted(sections, key=lambda e: e.get("heading_level", 0), reverse=True)
+
+    ids_to_remove = set()
+
+    for section in sections_by_depth:
+        sid = section["id"]
+        if sid in ids_to_remove:
+            continue
+
+        # Skip sections that have children
+        if _has_children(sid, entries):
+            continue
+
+        # Estimate tokens from summary + keywords
+        text = (section.get("summary", "") + " " + " ".join(section.get("keywords", []))).strip()
+        tokens = estimate_tokens(text)
+
+        if tokens >= min_tokens:
+            continue
+
+        # Find merge target: previous sibling (same parent, same source) or parent
+        parent_id = section.get("parent")
+        source_pfx = _source_prefix(sid)
+
+        # Find siblings: same parent, same source prefix, section tier, not marked for removal
+        siblings = [
+            e for e in entries
+            if e.get("parent") == parent_id
+            and e.get("tier") == "section"
+            and _source_prefix(e["id"]) == source_pfx
+            and e["id"] != sid
+            and e["id"] not in ids_to_remove
+        ]
+
+        # Find the previous sibling by line_range
+        prev_sibling = None
+        section_start = (section.get("line_range") or [0])[0]
+        for sib in siblings:
+            sib_start = (sib.get("line_range") or [0])[0]
+            if sib_start < section_start:
+                if prev_sibling is None or sib_start > (prev_sibling.get("line_range") or [0])[0]:
+                    prev_sibling = sib
+
+        if prev_sibling:
+            target = prev_sibling
+            target_id = target["id"]
+        elif parent_id:
+            # Merge into parent
+            target = next((e for e in entries if e["id"] == parent_id), None)
+            if target is None:
+                continue
+            target_id = target["id"]
+        else:
+            continue
+
+        # Verify same source
+        if _source_prefix(target_id) != source_pfx:
+            continue
+
+        # Perform merge
+        target_kw = target.get("keywords", [])
+        section_kw = section.get("keywords", [])
+        target["keywords"] = list(dict.fromkeys(target_kw + section_kw))  # deduplicated, order-preserving
+
+        # Extend line_range if target is a section
+        if target.get("line_range") and section.get("line_range"):
+            target["line_range"][1] = max(target["line_range"][1], section["line_range"][1])
+
+        # Append summary snippet
+        if section.get("summary"):
+            target["summary"] = (target.get("summary", "") + " " + section["summary"]).strip()
+
+        ids_to_remove.add(sid)
+        merged_log.append({
+            "removed_id": sid,
+            "merged_into": target_id,
+            "reason": f"{tokens} tokens (below {min_tokens} threshold)",
+        })
+
+    # Remove merged entries
+    work["entries"] = [e for e in entries if e["id"] not in ids_to_remove]
+    work["meta"]["entry_count"] = len(work["entries"])
+
+    sections_after = len([e for e in work["entries"] if e.get("tier") == "section"])
+
+    if dry_run:
+        return {
+            "sections_before": sections_before,
+            "sections_after": sections_after,
+            "merged": merged_log,
+        }
+
+    return work
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Thin section entries in index.yaml")
+    parser.add_argument("--index", required=True, help="Path to index.yaml")
+    parser.add_argument("--min-tokens", type=int, default=300, help="Min tokens per section (default: 300)")
+    parser.add_argument("--dry-run", action="store_true", help="Show plan without modifying")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    index_path = Path(args.index)
+
+    if not index_path.exists():
+        print(f"error: index not found: {args.index}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        import yaml
+    except ImportError:
+        print("error: PyYAML required for thin_sections.py", file=sys.stderr)
+        sys.exit(1)
+
+    with open(index_path) as f:
+        index = yaml.safe_load(f)
+
+    if args.dry_run:
+        result = thin_sections(index, args.min_tokens, dry_run=True)
+        print(json.dumps(result, indent=2))
+    else:
+        result = thin_sections(index, args.min_tokens, dry_run=False)
+        with open(index_path, "w") as f:
+            yaml.dump(result, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+        summary = {
+            "sections_before": len([e for e in index.get("entries", []) if e.get("tier") == "section"]),
+            "sections_after": len([e for e in result["entries"] if e.get("tier") == "section"]),
+            "merged": [],  # not tracked in non-dry-run for simplicity
+        }
+        print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception as e:
+        print(f"error: {e}", file=sys.stderr)
+        sys.exit(2)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /home/nathanielramm/git/hiivmind/hiivmind-corpus && python3 -m pytest lib/corpus/scripts/tests/test_thin_sections.py -v`
+Expected: 6 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/corpus/scripts/thin_sections.py lib/corpus/scripts/tests/test_thin_sections.py
+git commit -m "feat: add section tree thinning (thin_sections.py)"
+```
+
+---
+
+## Task 7: chunk.py Headings Strategy
+
+**Files:**
+- Modify: `lib/corpus/scripts/chunk.py`
+- Create: `lib/corpus/scripts/tests/test_chunk_headings.py`
+
+Add a `headings` strategy to the existing `chunk.py` that uses `split_by_headings` for primary boundaries and falls back to paragraph splitting within large sections. Each chunk carries a `heading_context` field.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# lib/corpus/scripts/tests/test_chunk_headings.py
+"""Tests for chunk.py headings strategy.
+
+Unit tests (no external deps):
+  - Sections within target are single chunks
+  - Large sections split at paragraphs
+  - heading_context is populated
+  - Overlap only on paragraph splits, not heading boundaries
+  - Falls back to markdown strategy for files without headings
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+class TestHeadingsStrategy:
+    def test_sections_within_target_are_single_chunks(self):
+        from chunk import chunk_text
+
+        text = (
+            "## Section One\n\nShort content.\n\n"
+            "## Section Two\n\nAnother short section.\n"
+        )
+        chunks = chunk_text(text, strategy="headings", target_tokens=100, overlap_tokens=10)
+        assert len(chunks) == 2
+        assert "heading_context" in chunks[0]
+        assert chunks[0]["heading_context"] == "## Section One"
+        assert chunks[1]["heading_context"] == "## Section Two"
+
+    def test_large_sections_split_at_paragraphs(self):
+        from chunk import chunk_text
+
+        text = "## Big Section\n\n"
+        for i in range(20):
+            text += f"Paragraph {i}. " * 20 + "\n\n"
+        chunks = chunk_text(text, strategy="headings", target_tokens=50, overlap_tokens=10)
+        assert len(chunks) > 1
+        # All chunks should have the same heading context
+        for c in chunks:
+            assert c["heading_context"] == "## Big Section"
+
+    def test_no_overlap_at_heading_boundaries(self):
+        from chunk import chunk_text
+
+        text = (
+            "## First\n\nContent one.\n\n"
+            "## Second\n\nContent two.\n"
+        )
+        chunks = chunk_text(text, strategy="headings", target_tokens=100, overlap_tokens=10)
+        if len(chunks) >= 2:
+            assert chunks[1].get("overlap_prev") is False
+
+    def test_overlap_on_paragraph_splits(self):
+        from chunk import chunk_text
+
+        text = "## Section\n\n"
+        for i in range(20):
+            text += f"Paragraph {i}. " * 20 + "\n\n"
+        chunks = chunk_text(text, strategy="headings", target_tokens=50, overlap_tokens=10)
+        if len(chunks) >= 2:
+            assert chunks[1].get("overlap_prev") is True
+
+    def test_nested_heading_context(self):
+        from chunk import chunk_text
+
+        text = (
+            "## Parent\n\nIntro.\n\n"
+            "### Child\n\nChild content.\n"
+        )
+        chunks = chunk_text(text, strategy="headings", target_tokens=100, overlap_tokens=0)
+        child_chunks = [c for c in chunks if "Child" in c.get("text", "")]
+        if child_chunks:
+            assert "Parent" in child_chunks[0]["heading_context"]
+            assert "Child" in child_chunks[0]["heading_context"]
+
+    def test_no_headings_falls_back(self):
+        from chunk import chunk_text
+
+        text = "Just plain text.\n" * 50
+        chunks = chunk_text(text, strategy="headings", target_tokens=20, overlap_tokens=5)
+        assert len(chunks) >= 1
+        # Should still work, falling back to paragraph splitting
+        for c in chunks:
+            assert "heading_context" in c
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /home/nathanielramm/git/hiivmind/hiivmind-corpus && python3 -m pytest lib/corpus/scripts/tests/test_chunk_headings.py -v`
+Expected: FAIL — `ValueError` or `KeyError` because `headings` strategy doesn't exist yet
+
+- [ ] **Step 3: Read current chunk.py to find insertion points**
+
+Read: `lib/corpus/scripts/chunk.py` — full file. Note:
+- `BOUNDARY_SCORES` dict at top (add `"headings"` key)
+- `STRATEGY_DEFAULTS` dict (add `"headings"` defaults)
+- `chunk_text()` function — the main function that dispatches on strategy
+- `parse_args()` — add `"headings"` to choices
+
+- [ ] **Step 4: Add headings strategy to chunk.py**
+
+The changes to `chunk.py`:
+
+1. Add `"headings"` to `BOUNDARY_SCORES` and `STRATEGY_DEFAULTS`:
+
+```python
+BOUNDARY_SCORES = {
+    ...existing strategies...
+    "headings": {"heading": 100, "blank_line": 20},
+}
+
+STRATEGY_DEFAULTS = {
+    ...existing strategies...
+    "headings": {"target_tokens": 900, "overlap_tokens": 100},
+}
+```
+
+2. Add `"headings"` to `parse_args()` choices:
+
+```python
+parser.add_argument("--strategy",
+    choices=["markdown", "transcript", "code", "paragraph", "headings"],
+    default="markdown", help="Chunking strategy (default: markdown)")
+```
+
+3. Add heading-aware chunking logic to `chunk_text()`. Before the existing boundary-scoring code, add a branch for the headings strategy that:
+   - Imports and calls `split_by_headings` to get section boundaries
+   - For sections that fit in `target_tokens`, emits them as single chunks with `heading_context`
+   - For sections that exceed `target_tokens`, splits at paragraph boundaries with overlap
+   - Falls back to the existing markdown strategy if no headings found
+
+The exact code depends on the current structure of `chunk_text()`. Read the full function, then add a new branch at the top:
+
+```python
+if strategy == "headings":
+    from split_by_headings import split_by_headings as _split_headings
+    sections = _split_headings(text, min_level=1, max_level=6, min_tokens=0)
+    if not sections:
+        # No headings found — fall back to paragraph splitting
+        return _chunk_paragraphs(lines, target_tokens, overlap_tokens, heading_context="")
+    return _chunk_by_sections(lines, sections, target_tokens, overlap_tokens)
+```
+
+Add helper functions `_chunk_by_sections()` and `_chunk_paragraphs()`:
+
+```python
+def _build_heading_context(sections, current_line):
+    """Build ancestor heading chain for a line number."""
+    context_parts = []
+    for s in sections:
+        if s["line_start"] <= current_line <= s["line_end"]:
+            context_parts.append(f"{'#' * s['level']} {s['title']}")
+    return " > ".join(context_parts) if context_parts else ""
+
+
+def _chunk_paragraphs(lines, target_tokens, overlap_tokens, heading_context, start_line=1):
+    """Split lines into chunks at paragraph boundaries with overlap."""
+    chunks = []
+    current_lines = []
+    current_tokens = 0
+    chunk_start = start_line
+
+    for i, line in enumerate(lines):
+        line_tokens = int(len(line.split()) * TOKENS_PER_WORD)
+        if current_tokens + line_tokens > target_tokens and current_lines:
+            chunk_text_str = "\n".join(current_lines)
+            chunks.append({
+                "text": chunk_text_str,
+                "line_range": [chunk_start, start_line + i - 1],
+                "chunk_index": len(chunks),
+                "overlap_prev": len(chunks) > 0 and overlap_tokens > 0,
+                "heading_context": heading_context,
+            })
+            # Overlap: keep last N tokens worth of lines
+            if overlap_tokens > 0:
+                overlap_lines = []
+                overlap_count = 0
+                for prev_line in reversed(current_lines):
+                    overlap_count += int(len(prev_line.split()) * TOKENS_PER_WORD)
+                    overlap_lines.insert(0, prev_line)
+                    if overlap_count >= overlap_tokens:
+                        break
+                current_lines = overlap_lines
+                current_tokens = overlap_count
+                chunk_start = start_line + i - len(overlap_lines)
+            else:
+                current_lines = []
+                current_tokens = 0
+                chunk_start = start_line + i
+        current_lines.append(line)
+        current_tokens += line_tokens
+
+    if current_lines:
+        chunks.append({
+            "text": "\n".join(current_lines),
+            "line_range": [chunk_start, start_line + len(lines) - 1],
+            "chunk_index": len(chunks),
+            "overlap_prev": len(chunks) > 0 and overlap_tokens > 0,
+            "heading_context": heading_context,
+        })
+    return chunks
+
+
+def _chunk_by_sections(all_lines, sections, target_tokens, overlap_tokens):
+    """Chunk by heading sections, splitting large sections at paragraphs."""
+    chunks = []
+    for section in sections:
+        start = section["line_start"] - 1  # 0-indexed
+        end = section["line_end"]  # exclusive for slicing
+        section_lines = all_lines[start:end]
+        section_tokens = int(len(" ".join(section_lines).split()) * TOKENS_PER_WORD)
+        heading_context = f"{'#' * section['level']} {section['title']}"
+
+        if section_tokens <= target_tokens:
+            chunks.append({
+                "text": "\n".join(section_lines),
+                "line_range": [section["line_start"], section["line_end"]],
+                "chunk_index": len(chunks),
+                "overlap_prev": False,
+                "heading_context": heading_context,
+            })
+        else:
+            sub_chunks = _chunk_paragraphs(
+                section_lines, target_tokens, overlap_tokens,
+                heading_context, start_line=section["line_start"]
+            )
+            for sc in sub_chunks:
+                sc["chunk_index"] = len(chunks)
+                chunks.append(sc)
+    return chunks
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd /home/nathanielramm/git/hiivmind/hiivmind-corpus && python3 -m pytest lib/corpus/scripts/tests/test_chunk_headings.py lib/corpus/scripts/tests/test_chunk.py -v`
+Expected: All tests pass (both new headings tests and existing tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/corpus/scripts/chunk.py lib/corpus/scripts/tests/test_chunk_headings.py
+git commit -m "feat: add headings chunking strategy to chunk.py"
+```
+
+---
+
+## Task 8: embed.py — heading_context in Chunk Embeddings
+
+**Files:**
+- Modify: `lib/corpus/scripts/embed.py`
+
+When embedding chunks that have a `heading_context` field, prepend it to the embedding text.
+
+- [ ] **Step 1: Read embed.py to find the chunk embedding text construction**
+
+Read: `lib/corpus/scripts/embed.py` — find the section where chunk text is constructed for embedding. Look for where `PASSAGE_PREFIX` is used with chunk data.
+
+- [ ] **Step 2: Modify chunk embedding text to include heading_context**
+
+Find the line where chunk embedding text is constructed (something like `text = chunk["text"]` or `text = PASSAGE_PREFIX + chunk["chunk_text"]`) and change it to:
+
+```python
+heading_ctx = chunk.get("heading_context", "")
+raw_text = chunk.get("chunk_text", chunk.get("text", ""))
+if heading_ctx:
+    text = f"{PASSAGE_PREFIX}{heading_ctx} | {raw_text}"
+else:
+    text = f"{PASSAGE_PREFIX}{raw_text}"
+```
+
+- [ ] **Step 3: Run existing embed tests to verify no regression**
+
+Run: `cd /home/nathanielramm/git/hiivmind/hiivmind-corpus && python3 -m pytest lib/corpus/scripts/tests/test_embed.py -v`
+Expected: All existing tests still pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/corpus/scripts/embed.py
+git commit -m "feat: prepend heading_context to chunk embeddings"
+```
+
+---
+
+## Task 9: Source-Scanner Agent Prompt Updates
+
+**Files:**
+- Modify: `agents/source-scanner.md`
+
+Add three new steps with GUARD blocks matching existing pseudocode patterns: Step 0 (nav detection), Step 1b (large file splitting), and chunking strategy selection.
+
+- [ ] **Step 1: Read the current source-scanner agent prompt**
+
+Read: `agents/source-scanner.md` — full file. Note the existing step numbering, format, and pseudocode style.
+
+- [ ] **Step 2: Add Step 0 (nav detection) before existing Step 1**
+
+Insert before the existing file discovery step. Use the exact pseudocode from the spec's `STEP_0_NAV_DETECTION()` block. Key elements:
+- Pre-check: source root accessible
+- Run `python3 ${PLUGIN_ROOT}/lib/corpus/scripts/detect_nav.py --source-root {source_root}`
+- Graceful fallback on script failure
+- Coverage threshold decision (>=80 auto-use, 50-80 ask user, <50 fallback)
+- Post-check: DISPLAY coverage info
+
+- [ ] **Step 3: Add Step 1b (large file splitting) after file discovery**
+
+Insert after file discovery. Use the exact pseudocode from the spec's `STEP_1B_LARGE_FILE_SPLITTING()` block. Key elements:
+- Pre-check: `computed.file_list` exists
+- Skip when `large_file_threshold == 0`
+- Run `detect_large_files.py` then `split_by_headings.py` per file
+- Post-check: DISPLAY split summary
+
+- [ ] **Step 4: Add chunking strategy selection**
+
+In the existing chunking step, add strategy auto-selection logic from the spec's `STEP_CHUNKING_STRATEGY_SELECTION()` block. If `computed.nav_skeleton` exists or `heading_consistency == "high"`, use `headings` strategy.
+
+- [ ] **Step 5: Update the Reference section**
+
+Add the five new features to the source-scanner's reference section listing related skills and features.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add agents/source-scanner.md
+git commit -m "feat: add nav detection, large file splitting, and chunking strategy to source-scanner"
+```
+
+---
+
+## Task 10: Build Skill Prompt Updates
+
+**Files:**
+- Modify: `skills/hiivmind-corpus-build/SKILL.md`
+
+Add GUARD blocks for tree thinning (after Phase 2c) and verification (Phase 7c).
+
+- [ ] **Step 1: Read the current build skill**
+
+Read: `skills/hiivmind-corpus-build/SKILL.md` — find Phase 2c (section indexing), Phase 7/7b (embeddings), and Phase 8 (save).
+
+- [ ] **Step 2: Add tree thinning GUARD after Phase 2c**
+
+Insert the `GUARD_TREE_THINNING()` pseudocode block from the spec between Phase 2c and Phase 3. Key elements:
+- Pre-check: section entries exist in scan results
+- Skip when `min_section_tokens` not configured
+- Dry-run first, present merge plan
+- User confirmation `[Y/n]` before applying
+
+- [ ] **Step 3: Add verification GUARD as Phase 7c**
+
+Insert the `GUARD_PHASE_7C_VERIFICATION()` pseudocode block from the spec after Phase 7b and before Phase 8. Key elements:
+- GUARD: `computed.index` exists
+- Skip: `verify_on_build` disabled or entry_count >= 200 (default heuristic)
+- Run `verify_entries.py --sample N`
+- LLM verification in batches
+- Present inaccurate entries with `[Y/n]` regeneration prompt
+
+- [ ] **Step 4: Update Phase 8 GUARD to verify Phase 7c was evaluated**
+
+Add `Phase 7c (Verification) evaluated` to the Phase 8 guard check, matching the existing pattern where Phase 8 verifies all prior phases ran.
+
+- [ ] **Step 5: Update the Reference section**
+
+Add the five new features to the build skill's reference section.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add skills/hiivmind-corpus-build/SKILL.md
+git commit -m "feat: add tree thinning and verification guards to build skill"
+```
+
+---
+
+## Task 11: Refresh Skill Prompt Updates
+
+**Files:**
+- Modify: `skills/hiivmind-corpus-refresh/SKILL.md`
+
+Add optional post-refresh verification step.
+
+- [ ] **Step 1: Read the current refresh skill**
+
+Read: `skills/hiivmind-corpus-refresh/SKILL.md` — find Phase 6 (Apply Changes) and the existing embedding update logic.
+
+- [ ] **Step 2: Add verification guard after Phase 6**
+
+Insert the `GUARD_REFRESH_VERIFICATION()` pseudocode block from the spec. Key elements:
+- Pre-check: `computed.changes_applied` exists
+- Skip: only deletions applied
+- Run `verify_entries.py --entries {modified_ids}`
+- LLM verification
+- Present inaccurate entries with `[Y/n]` prompt
+
+- [ ] **Step 3: Update the Reference section**
+
+Add the five new features to the refresh skill's reference section.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/hiivmind-corpus-refresh/SKILL.md
+git commit -m "feat: add post-refresh verification to refresh skill"
+```
+
+---
+
+## Task 12: CLAUDE.md Cross-Cutting Concerns Update
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Read the current cross-cutting concerns table**
+
+Read: `CLAUDE.md` — find the `### Cross-Cutting Concerns` section and the feature table.
+
+- [ ] **Step 2: Add five new rows to the table**
+
+Add these rows to the cross-cutting concerns table:
+
+```markdown
+| Nav detection | source-scanner, build, add-source | `detect_nav.py` called before glob scan, coverage threshold logic |
+| Verification loop | build, refresh | `verify_entries.py` + LLM verification, config flag |
+| Tree thinning | build, enhance, refresh | `thin_sections.py` post-processing, `min_section_tokens` config |
+| Large-node splitting | source-scanner, build | `detect_large_files.py` + `split_by_headings.py`, interaction with section indexing |
+| Structure-aware chunking | build, source-scanner, navigate | `headings` strategy in `chunk.py`, `heading_context` in embeddings |
+```
+
+- [ ] **Step 3: Update the Skill Dependency Chain**
+
+Add the new scripts to the dependency chain diagram:
+
+```
+build ──► detect_nav.py, detect_large_files.py, split_by_headings.py (Phase 2)
+build ──► thin_sections.py (post Phase 2c)
+build ──► verify_entries.py (Phase 7c)
+refresh ──► verify_entries.py (post Phase 6)
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: add PageIndex build enhancements to cross-cutting concerns"
+```
+
+---
+
+## Task 13: Run Full Test Suite
+
+**Files:** None modified. Verification only.
+
+- [ ] **Step 1: Run all script tests**
+
+Run: `cd /home/nathanielramm/git/hiivmind/hiivmind-corpus && python3 -m pytest lib/corpus/scripts/tests/ -v`
+Expected: All tests pass.
+
+- [ ] **Step 2: Verify no import errors across scripts**
+
+Run each script with `--help` to verify imports work:
+
+```bash
+python3 lib/corpus/scripts/detect_nav.py --help
+python3 lib/corpus/scripts/verify_entries.py --help
+python3 lib/corpus/scripts/thin_sections.py --help
+python3 lib/corpus/scripts/detect_large_files.py --help
+python3 lib/corpus/scripts/split_by_headings.py --help
+python3 lib/corpus/scripts/chunk.py --help
+```
+
+Expected: All print usage and exit 0.
+
+- [ ] **Step 3: Check spec acceptance criteria**
+
+Walk each acceptance criterion from `docs/superpowers/specs/2026-04-10-pageindex-build-enhancements-design.md` and confirm it is implemented. Report any gaps.

--- a/docs/superpowers/specs/2026-04-10-pageindex-build-enhancements-design.md
+++ b/docs/superpowers/specs/2026-04-10-pageindex-build-enhancements-design.md
@@ -559,6 +559,247 @@ This means a chunk from "## Data Modeling > ### Primary Keys" gets embedded with
 
 ---
 
+## Skill and Agent Integration: Guards, Skips, and Post-Checks
+
+Each algorithm integration follows the existing patterns: GUARD blocks at phase entry, skip conditions for optional features, and post-step verification with user-facing summaries.
+
+### Source-Scanner Agent Updates
+
+The source-scanner agent (`agents/source-scanner.md`) gains three new steps. Each follows the existing step format with inline verification.
+
+**New Step 0: Check for navigation structure** (before existing Step 1: File Discovery)
+
+```pseudocode
+STEP_0_NAV_DETECTION():
+  # Pre-check: source root must be resolved
+  IF source_root IS NOT accessible:
+    SKIP "Cannot check nav structure: source root not resolved"
+    PROCEED to Step 1 (existing file discovery)
+
+  result = Bash("python3 ${PLUGIN_ROOT}/lib/corpus/scripts/detect_nav.py --source-root {source_root}")
+
+  IF result.exit_code != 0:
+    DISPLAY "Nav detection failed: {stderr}. Falling back to file scanning."
+    PROCEED to Step 1
+
+  IF result.found == false:
+    PROCEED to Step 1
+
+  # Post-check: evaluate coverage
+  IF result.coverage.coverage_pct >= 80:
+    computed.nav_skeleton = result.hierarchy
+    computed.nav_source = result.nav_file
+    DISPLAY "Found {result.nav_file} with {result.coverage.coverage_pct}% coverage ({result.coverage.files_resolved}/{result.coverage.nav_entries} files resolved). Using nav skeleton."
+    # Step 1 file discovery will use nav_skeleton as entry list, scan remaining files normally
+  ELIF result.coverage.coverage_pct >= 50:
+    DISPLAY "Found {result.nav_file} with {result.coverage.coverage_pct}% coverage. {result.coverage.files_missing} files referenced but not found."
+    ASK user: "Use this nav structure as the index skeleton? Files outside the nav will still be scanned. [Y/n]"
+    IF user approves:
+      computed.nav_skeleton = result.hierarchy
+  ELSE:
+    DISPLAY "Found {result.nav_file} but only {result.coverage.coverage_pct}% coverage. Falling back to file scanning."
+    PROCEED to Step 1
+```
+
+**New Step 1b: Detect and split large files** (after existing Step 1: File Discovery, before Step 2: Sample Files)
+
+```pseudocode
+STEP_1B_LARGE_FILE_SPLITTING():
+  # Pre-check: file discovery must have completed
+  IF computed.file_list IS null OR len(computed.file_list) == 0:
+    SKIP "No files discovered. Skipping large file detection."
+    PROCEED to Step 2
+
+  # Skip condition: check if feature is disabled
+  large_threshold = config.build.large_file_threshold OR 15000
+  IF large_threshold == 0:
+    SKIP "Large file splitting disabled (threshold = 0)."
+    PROCEED to Step 2
+
+  result = Bash("python3 ${PLUGIN_ROOT}/lib/corpus/scripts/detect_large_files.py --source-root {source_root} --max-tokens {large_threshold}")
+
+  IF result.exit_code != 0:
+    DISPLAY "Large file detection failed: {stderr}. Continuing without splitting."
+    PROCEED to Step 2
+
+  IF len(result) == 0:
+    DISPLAY "No files exceed {large_threshold} token threshold."
+    PROCEED to Step 2
+
+  # Post-check: split each large file that has headings
+  computed.large_files = result
+  computed.split_entries = []
+  FOR file IN result:
+    IF file.has_headings:
+      split = Bash("python3 ${PLUGIN_ROOT}/lib/corpus/scripts/split_by_headings.py --file {source_root}/{file.path} --min-tokens 200")
+      IF split.exit_code == 0 AND len(split) > 1:
+        computed.split_entries.append({file: file.path, sections: split})
+        DISPLAY "Split {file.path} ({file.token_count} tokens) into {len(split)} sections."
+      ELSE:
+        DISPLAY "Could not split {file.path} by headings. Will use GREP marker fallback."
+    ELSE:
+      DISPLAY "{file.path} ({file.token_count} tokens) has no heading structure. Using size: large + grep_hint."
+
+  # Summary
+  split_count = sum(len(s.sections) for s in computed.split_entries)
+  fallback_count = len(result) - len(computed.split_entries)
+  DISPLAY "Large files: {len(result)} detected, {split_count} sub-entries generated, {fallback_count} using GREP fallback."
+```
+
+**Modified Step (chunking):** When chunking is enabled, select strategy based on heading analysis.
+
+```pseudocode
+STEP_CHUNKING_STRATEGY_SELECTION():
+  # Pre-check: chunking must be enabled for this source
+  IF source.chunking.enabled != true:
+    SKIP chunking entirely
+
+  strategy = source.chunking.strategy OR "auto"
+
+  IF strategy == "auto":
+    # Use heading analysis from Step 0 or Step 1b
+    IF computed.nav_skeleton IS NOT null:
+      strategy = "headings"
+    ELIF computed.heading_consistency == "high":
+      strategy = "headings"
+    ELSE:
+      strategy = "markdown"  # existing default
+
+  DISPLAY "Chunking strategy for {source.id}: {strategy}"
+  # Proceed with selected strategy
+```
+
+### Build Skill Updates
+
+**New GUARD for verification (after Phase 7b, before Phase 8):**
+
+```pseudocode
+GUARD_PHASE_7C_VERIFICATION():
+  IF computed.index IS null:
+    DISPLAY "Cannot verify: index has not been generated."
+    EXIT
+
+  # Skip condition
+  verify_enabled = config.build.verify_on_build
+  IF verify_enabled IS null:
+    # Default: true for <200 entries, false otherwise
+    verify_enabled = (computed.index.meta.entry_count < 200)
+
+  IF verify_enabled == false:
+    SKIP "Verification skipped (verify_on_build: false or entry_count >= 200)."
+    PROCEED to Phase 8
+
+  sample_size = config.build.verify_sample_size OR 20
+  IF sample_size > computed.index.meta.entry_count:
+    sample_size = 0  # 0 means all
+
+  result = Bash("python3 ${PLUGIN_ROOT}/lib/corpus/scripts/verify_entries.py --index index.yaml --source-root .source/ --sample {sample_size}")
+
+  IF result.exit_code != 0:
+    DISPLAY "Verification script failed: {stderr}. Proceeding without verification."
+    PROCEED to Phase 8
+
+  IF len(result) == 0:
+    DISPLAY "No entries to verify (all entries may be remote-only)."
+    PROCEED to Phase 8
+
+  # LLM verification of extracted previews (batched)
+  inaccurate = []
+  FOR batch IN chunk(result, size=10):
+    verification = LLM_CALL("For each entry, check if summary matches content_preview.
+                              Return [{entry_id, accurate: true/false, issue: '...'}]", batch)
+    inaccurate.extend([v for v in verification if v.accurate == false])
+
+  # Post-check: present results
+  IF len(inaccurate) == 0:
+    DISPLAY "Verification passed: {len(result)} entries checked, all accurate."
+  ELSE:
+    DISPLAY "Verification found {len(inaccurate)} entries with summary drift:"
+    FOR entry IN inaccurate:
+      DISPLAY "  - {entry.entry_id}: {entry.issue}"
+    ASK user: "Regenerate summaries for these entries? [Y/n]"
+    IF user approves:
+      regenerate_summaries(inaccurate)
+      IF index-embeddings.lance/ exists:
+        re_embed(inaccurate)
+```
+
+**New GUARD for tree thinning (after Phase 2c section indexing, before Phase 5):**
+
+```pseudocode
+GUARD_TREE_THINNING():
+  # Pre-check: section entries must exist
+  section_count = count(entry for entry in computed.scan_results if entry.tier == "section")
+  IF section_count == 0:
+    SKIP "No section entries to thin."
+    PROCEED to next phase
+
+  # Skip condition: min_section_tokens must be configured
+  has_token_config = ANY(source.sections.min_section_tokens IS NOT null for source in config.sources)
+  IF NOT has_token_config:
+    SKIP "Tree thinning not configured (no min_section_tokens in any source)."
+    PROCEED to next phase
+
+  result = Bash("python3 ${PLUGIN_ROOT}/lib/corpus/scripts/thin_sections.py --index index.yaml --min-tokens {min_section_tokens} --dry-run")
+
+  IF result.exit_code != 0:
+    DISPLAY "Tree thinning failed: {stderr}. Proceeding with unthinned sections."
+    PROCEED to next phase
+
+  IF result.sections_before == result.sections_after:
+    DISPLAY "Tree thinning: all {result.sections_before} sections above token threshold. No merges needed."
+    PROCEED to next phase
+
+  # Post-check: present merge plan and confirm
+  DISPLAY "Tree thinning would merge {result.sections_before - result.sections_after} sections:"
+  FOR merge IN result.merged[:10]:  # show first 10
+    DISPLAY "  - {merge.removed_id} → {merge.merged_into} ({merge.reason})"
+  IF len(result.merged) > 10:
+    DISPLAY "  ... and {len(result.merged) - 10} more."
+
+  ASK user: "Apply these merges? [Y/n]"
+  IF user approves:
+    Bash("python3 ${PLUGIN_ROOT}/lib/corpus/scripts/thin_sections.py --index index.yaml --min-tokens {min_section_tokens}")
+    DISPLAY "Thinned: {result.sections_before} → {result.sections_after} sections."
+```
+
+### Refresh Skill Updates
+
+**New optional step after Phase 6 (Apply Changes):**
+
+```pseudocode
+GUARD_REFRESH_VERIFICATION():
+  # Pre-check: changes must have been applied
+  IF computed.changes_applied IS null OR len(computed.changes_applied) == 0:
+    SKIP "No changes applied. Skipping verification."
+    PROCEED to Phase 7
+
+  # Skip condition: only verify if entries were actually modified
+  modified_ids = [c.entry_id for c in computed.changes_applied if c.action in ("modified", "added")]
+  IF len(modified_ids) == 0:
+    SKIP "Only deletions applied. Skipping verification."
+    PROCEED to Phase 7
+
+  result = Bash("python3 ${PLUGIN_ROOT}/lib/corpus/scripts/verify_entries.py --index index.yaml --source-root .source/ --entries {','.join(modified_ids)}")
+
+  IF result.exit_code != 0:
+    DISPLAY "Post-refresh verification failed: {stderr}. Proceeding without verification."
+    PROCEED to Phase 7
+
+  # LLM verification (same pattern as build)
+  inaccurate = []
+  FOR batch IN chunk(result, size=10):
+    verification = LLM_CALL(...)
+    inaccurate.extend(...)
+
+  IF len(inaccurate) > 0:
+    DISPLAY "Post-refresh verification found {len(inaccurate)} entries with summary drift."
+    ASK user: "Regenerate? [Y/n]"
+    ...
+```
+
+---
+
 ## Cross-Cutting Concerns
 
 ### Script dependencies
@@ -627,6 +868,16 @@ New rows for CLAUDE.md cross-cutting concerns:
 - [ ] Each chunk carries `heading_context` (ancestor heading chain).
 - [ ] `embed.py` prepends `heading_context` to chunk embedding text.
 - [ ] Existing chunking strategies (`markdown`, `transcript`, `code`, `paragraph`) are unchanged.
+
+### Guards, Skips, and Post-Checks
+- [ ] Source-scanner Step 0 (nav detection) has pre-check for source root accessibility, graceful fallback on script failure, and coverage-threshold decision logic with user prompt at 50–80%.
+- [ ] Source-scanner Step 1b (large files) has pre-check for `computed.file_list`, skip when `large_file_threshold == 0`, graceful fallback on script failure, and post-step summary of split vs fallback counts.
+- [ ] Source-scanner chunking step has pre-check for `chunking.enabled`, auto-strategy selection based on heading analysis, and strategy display.
+- [ ] Build Phase 7c (verification) has GUARD for `computed.index`, skip condition based on `verify_on_build` config with default heuristic, graceful fallback on script failure, and post-check presenting inaccurate entries with regeneration prompt.
+- [ ] Build tree-thinning step has pre-check for section entry existence, skip when `min_section_tokens` not configured, dry-run preview before applying, and user confirmation gate.
+- [ ] Refresh verification step has pre-check for `computed.changes_applied`, skip when only deletions applied, and targets only modified/added entries.
+- [ ] All new steps degrade gracefully: script failure → DISPLAY warning → PROCEED to next phase (never EXIT on script failure).
+- [ ] All new steps with user interaction offer `[Y/n]` confirmation before modifying index.yaml.
 
 ### Integration
 - [ ] All scripts exit 0 with JSON stdout on success, exit 1 with stderr on error.

--- a/docs/superpowers/specs/2026-04-10-pageindex-build-enhancements-design.md
+++ b/docs/superpowers/specs/2026-04-10-pageindex-build-enhancements-design.md
@@ -1,0 +1,635 @@
+# PageIndex-Inspired Build Enhancements — Design
+
+**Date:** 2026-04-10
+**Status:** Draft
+**Scope:** Five new deterministic scripts + source-scanner/build/refresh skill updates
+
+## Goal
+
+Adapt five algorithms from [VectifyAI/PageIndex](https://github.com/VectifyAI/PageIndex) to improve corpus build quality: exploit pre-existing navigation structure, verify index accuracy, merge trivially small sections, auto-split large files, and chunk at natural document boundaries.
+
+## Context
+
+PageIndex is a vectorless RAG system that builds hierarchical tree indexes from documents. Its build-time algorithms — particularly TOC detection, verification loops, tree thinning, recursive node splitting, and overlapping page groups — solve problems that corpus's current pipeline handles with simpler heuristics.
+
+These five algorithms slot into existing build phases as enhancements. No phases are removed or reordered. The index.yaml schema, embedding format, navigate skill, and user-facing workflow are unchanged.
+
+## Non-Goals
+
+- PageIndex's retrieval-time tree-reasoning (query-time LLM navigation of tree structure). We evaluated this and chose build-time only.
+- Using PageIndex as a runtime dependency. All algorithms are reimplemented as deterministic Python scripts + source-scanner prompt updates.
+- PDF-specific page-offset calculation (PageIndex maps logical page numbers to physical page numbers in PDFs with roman-numeral prefaces). Not relevant to corpus's text-based sources.
+- Changes to the navigate skill, embedding pipeline, or index.yaml schema.
+
+## Architecture
+
+All five algorithms follow the same pattern as existing `lib/corpus/scripts/`:
+
+- **Deterministic Python scripts** handle data preparation, parsing, counting, and transformation.
+- **LLM inference** (source-scanner agent, build/refresh skills) handles summarization, classification, and judgment calls.
+- **LLM orchestration** (build skill) handles user interaction and pipeline decisions.
+
+New scripts are standalone CLI tools with JSON input/output, callable via `python3 script.py [args]`.
+
+### Dependency on existing infrastructure
+
+| New script | Depends on | Notes |
+|---|---|---|
+| `detect_nav.py` | PyYAML (already optional dep) | Falls back to regex if unavailable |
+| `verify_entries.py` | PyYAML | Data prep only; LLM does actual verification |
+| `thin_sections.py` | PyYAML, fastembed (for token counting) | Falls back to word-count heuristic if no fastembed |
+| `detect_large_files.py` | None (uses `wc` or Python line/word counting) | Zero dependencies |
+| `split_by_headings.py` | None | Pure Python regex |
+| `chunk_with_overlap.py` | None | Extends existing `chunk.py` patterns |
+
+Token counting: scripts that need token counts use `fastembed`'s tokenizer if available, otherwise fall back to `len(text.split()) * 1.3` (word-count approximation). This matches corpus's existing "graceful degradation" principle.
+
+---
+
+## Algorithm 1: Nav Detection
+
+**Phase:** 2a (file discovery), new fast path before glob-and-scan
+**Type:** Deterministic script + LLM orchestration decision
+
+### Problem
+
+The source-scanner currently globs for all `.md`/`.mdx` files, groups by directory, and detects the documentation framework. Framework detection already finds `mkdocs.yml` but only reports the framework name — it doesn't parse the navigation structure. This means the scanner treats a well-organized MkDocs site the same as a random collection of markdown files.
+
+### Solution
+
+**Script:** `lib/corpus/scripts/detect_nav.py`
+
+```
+INTERFACE:
+  Input:  source_root (path to .source/{source_id}/ or uploads/{source_id}/)
+  Output: JSON to stdout
+    {
+      "found": true/false,
+      "nav_file": "mkdocs.yml" | "_sidebar.md" | "SUMMARY.md" | null,
+      "framework": "mkdocs" | "docsify" | "mdbook" | "gitbook" | "custom" | null,
+      "hierarchy": [
+        {
+          "title": "Getting Started",
+          "path": "docs/getting-started.md",
+          "level": 1,
+          "children": [
+            {"title": "Installation", "path": "docs/install.md", "level": 2, "children": []}
+          ]
+        }
+      ],
+      "coverage": {
+        "nav_entries": 45,
+        "files_resolved": 42,
+        "files_missing": 3,
+        "total_md_files": 50,
+        "coverage_pct": 84.0
+      }
+    }
+
+ALGORITHM:
+  1. Scan for nav files in priority order:
+     a. mkdocs.yml          → parse nav: key (YAML, recursive)
+     b. mkdocs.yaml         → same
+     c. docusaurus.config.js → parse sidebars object (regex extraction of sidebar items)
+     d. _sidebar.md          → parse "- [Title](path)" with indent nesting (docsify)
+     e. SUMMARY.md           → parse "- [Title](path)" with indent nesting (mdbook/gitbook)
+     f. _toc.yml             → parse YAML toc structure
+     g. book.toml + src/SUMMARY.md → mdbook variant
+  
+  2. If found, parse into hierarchy:
+     - Normalize all paths relative to source root
+     - Resolve each path: check file exists, record missing
+     - Compute coverage: files_resolved / total_md_files_in_source
+  
+  3. Output JSON to stdout
+
+FALLBACK:
+  If no nav file found: output {"found": false, ...}
+  If PyYAML unavailable and nav file is YAML: attempt regex extraction of
+    nav entries (pattern: "- title: ... path: ..." or "- Title: path"),
+    set framework: "custom", warn in stderr
+```
+
+**Source-scanner integration:**
+
+The source-scanner agent runs `detect_nav.py` as its first step. Decision logic:
+
+- If `coverage_pct >= 80`: Use the nav hierarchy as the entry skeleton. For each nav entry, read the file and generate summary/tags/keywords (Phase 2b, unchanged). Files not in the nav are scanned normally and appended.
+- If `coverage_pct` between 50–80: Present the nav hierarchy to the user and ask whether to use it or fall back to full scanning. Note which files are outside the nav.
+- If `coverage_pct < 50` or `found: false`: Fall back to current glob-and-scan approach (unchanged).
+
+### What changes in existing code
+
+- Source-scanner agent prompt (`agents/source-scanner.md`): Add "Step 0: Check for navigation structure" before file discovery.
+- `lib/corpus/patterns/scanning.md`: Add nav detection as first scanning strategy.
+- No changes to build skill, index.yaml schema, or config.yaml.
+
+---
+
+## Algorithm 2: Verification Loop
+
+**Phase:** New Phase 8.5 (between index generation and save), also available in refresh
+**Type:** Deterministic data-prep script + LLM inference
+
+### Problem
+
+After building or refreshing an index, there is no check that entry summaries actually match the content they describe. The refresh skill detects staleness by commit SHA comparison, but a stale entry might have an accurate summary (if the relevant content didn't change) or a fresh entry might have an inaccurate summary (if the scanner misread the file).
+
+### Solution
+
+**Script:** `lib/corpus/scripts/verify_entries.py`
+
+```
+INTERFACE:
+  Input:
+    --index PATH          (path to index.yaml)
+    --source-root PATH    (path to source root, e.g., .source/{source_id}/)
+    --token-limit N       (max tokens of content preview per entry, default 500)
+    --sample N            (verify N random entries instead of all, default: all)
+    --entries ID,ID,...    (verify specific entry IDs only, optional)
+  Output: JSON to stdout
+    [
+      {
+        "entry_id": "polars-docs:docs/guides/expressions.md",
+        "title": "Expressions",
+        "summary": "How to write and compose expressions...",
+        "source_path": "docs/guides/expressions.md",
+        "content_preview": "# Expressions\n\nPolars expressions are...",
+        "token_count": 487
+      },
+      ...
+    ]
+
+ALGORITHM:
+  1. Parse index.yaml
+  2. For each entry (or sampled/specified subset):
+     a. Resolve source_path against source-root
+     b. If file exists: read content, truncate to token_limit tokens
+     c. If file missing: emit entry with content_preview: null
+     d. Emit {entry_id, title, summary, source_path, content_preview, token_count}
+  3. Output JSON array to stdout
+
+NOTES:
+  - This is data preparation only. The script does NOT judge accuracy.
+  - For remote corpora (no local clone), skip verification and note in output.
+  - Token counting uses fastembed tokenizer if available, else word-count approximation.
+```
+
+**Build/refresh skill integration:**
+
+After generating or updating index.yaml, the build/refresh skill:
+
+1. Runs `verify_entries.py --sample 20` (or all entries for small corpora <50 entries).
+2. Feeds the output to the LLM in batches of ~10 entries:
+   ```
+   For each entry below, check whether the summary accurately describes
+   the content preview. Return JSON: [{entry_id, accurate: true/false, issue: "..."}]
+   ```
+3. Presents inaccurate entries to the user:
+   ```
+   Verification found 3 entries where summaries may not match content:
+   - expressions.md: Summary says "compose expressions" but content is about "expression contexts"
+   - ...
+   Regenerate summaries for these? [Y/n]
+   ```
+4. If user approves, regenerates summaries for flagged entries and re-embeds if embeddings exist.
+
+### Configuration
+
+New optional field in `config.yaml`:
+
+```yaml
+build:
+  verify_on_build: true    # default: true for corpora with <200 entries, false otherwise
+  verify_sample_size: 20   # entries to sample for verification, 0 = all
+```
+
+### What changes in existing code
+
+- Build skill (`skills/hiivmind-corpus-build/SKILL.md`): Add verification step after Phase 7/7b, before Phase 8.
+- Refresh skill (`skills/hiivmind-corpus-refresh/SKILL.md`): Add optional verification after updating stale entries.
+- `config.yaml` template: Add `build.verify_on_build` and `build.verify_sample_size` fields.
+- No changes to index.yaml schema, source-scanner, or navigate skill.
+
+---
+
+## Algorithm 3: Tree Thinning
+
+**Phase:** 2c (section indexing), replaces `min_content_lines` heuristic
+**Type:** Entirely deterministic
+
+### Problem
+
+Section indexing currently uses `min_content_lines` (default: 3) to filter out trivially small headings. This is a poor heuristic: a 3-line section with a code block might be 200 tokens of valuable content, while a 10-line section of boilerplate navigation links is noise. PageIndex's tree thinning uses token counts and bottom-up merging, which produces better results.
+
+### Solution
+
+**Script:** `lib/corpus/scripts/thin_sections.py`
+
+```
+INTERFACE:
+  Input:
+    --index PATH              (path to index.yaml)
+    --min-tokens N            (minimum tokens for a section to survive, default 300)
+    --dry-run                 (print what would be merged, don't modify)
+  Output:
+    Modified index.yaml (in-place) unless --dry-run
+    JSON summary to stdout:
+    {
+      "sections_before": 245,
+      "sections_after": 189,
+      "merged": [
+        {
+          "removed_id": "src:docs/api.md#parameters",
+          "merged_into": "src:docs/api.md#methods",
+          "reason": "42 tokens (below 300 threshold)"
+        }
+      ]
+    }
+
+ALGORITHM:
+  1. Parse index.yaml
+  2. Extract all entries with tier: section
+  3. Build parent-child tree:
+     - Group sections by their parent entry ID
+     - Order by line_range within each group
+     - Nest children based on heading_level
+  4. Bottom-up traversal (deepest sections first):
+     for each section:
+       total_tokens = estimate_tokens(section.summary + section.keywords)
+       if total_tokens < min_tokens AND section has no children:
+         mark for merge into nearest sibling or parent
+  5. For each marked section:
+     - If previous sibling exists: append summary to sibling, extend sibling line_range
+     - Else: append summary to parent entry's summary, remove section
+  6. Renumber/recount meta.entry_count
+  7. Write updated index.yaml (unless --dry-run)
+
+TOKEN ESTIMATION:
+  If fastembed available: use tokenizer
+  Else: len(text.split()) * 1.3 (English word-to-token approximation)
+
+MERGE RULES:
+  - Never merge a section that has children (merge children first, bottom-up)
+  - Never merge across different source files (parent must share same source_path prefix)
+  - Preserve the merged section's keywords by appending to target's keywords
+```
+
+### Configuration
+
+Section indexing config gains a new optional field:
+
+```yaml
+sources:
+  - id: docs
+    sections:
+      enabled: true
+      min_level: 2
+      min_content_lines: 3    # DEPRECATED, still honored if set
+      min_section_tokens: 300  # NEW, takes precedence over min_content_lines
+```
+
+If `min_section_tokens` is set, tree thinning runs as a post-processing step after section entries are generated. If only `min_content_lines` is set, the existing behavior is preserved. If both are set, `min_section_tokens` takes precedence.
+
+### What changes in existing code
+
+- Source-scanner agent (`agents/source-scanner.md`): No change. Section entries are still generated with the existing heading-depth approach.
+- Build skill (`skills/hiivmind-corpus-build/SKILL.md`): After Phase 2c generates section entries and before Phase 5 assembles index.yaml, run `thin_sections.py` if `min_section_tokens` is configured. Present the merge summary to the user.
+- `config.yaml` template: Add `min_section_tokens` field to sections config.
+- Existing corpora: No impact. `min_content_lines` continues to work. Tree thinning only activates when `min_section_tokens` is explicitly configured.
+
+---
+
+## Algorithm 4: Large-Node Splitting
+
+**Phase:** 2a–2b (scanning + metadata), upgrades `size: large` + GREP marker approach
+**Type:** Deterministic scripts + LLM inference for summaries
+
+### Problem
+
+Files exceeding 1000 lines currently get a `size: large` flag and a `grep_hint` for the GREP marker pattern. The user must manually decide how to handle them. For files with heading structure, the scanner could automatically generate sub-entries — the same thing section indexing does, but triggered by file size rather than explicit configuration.
+
+### Solution
+
+Two scripts, called in sequence:
+
+**Script:** `lib/corpus/scripts/detect_large_files.py`
+
+```
+INTERFACE:
+  Input:
+    --source-root PATH     (path to source root)
+    --max-tokens N         (threshold for "large", default 15000)
+    --paths FILE           (optional: only check these paths, one per line)
+  Output: JSON to stdout
+    [
+      {
+        "path": "docs/api/reference.md",
+        "token_count": 23400,
+        "line_count": 1842,
+        "has_headings": true,
+        "heading_count": 34,
+        "deepest_heading_level": 4
+      }
+    ]
+
+ALGORITHM:
+  1. For each .md/.mdx file in source-root (or specified paths):
+     a. Read file, count tokens (fastembed tokenizer or word approximation)
+     b. If token_count > max_tokens:
+        - Count headings (regex: /^#{1,6}\s/)
+        - Record deepest heading level
+        - Emit entry
+  2. Output JSON array to stdout
+```
+
+**Script:** `lib/corpus/scripts/split_by_headings.py`
+
+```
+INTERFACE:
+  Input:
+    --file PATH            (path to markdown file)
+    --min-level N          (minimum heading level to split at, default 2)
+    --max-level N          (maximum heading level to split at, default 4)
+    --min-tokens N         (minimum tokens for a split section, default 200)
+  Output: JSON to stdout
+    [
+      {
+        "title": "Authentication",
+        "level": 2,
+        "line_start": 45,
+        "line_end": 122,
+        "token_count": 3200,
+        "anchor": "authentication",
+        "text_preview": "## Authentication\n\nThe API uses OAuth 2.0..."
+      }
+    ]
+
+ALGORITHM:
+  1. Parse all headings (regex: /^(#{1,6})\s+(.+)$/, skip code blocks)
+  2. For each heading at min_level..max_level:
+     a. Calculate text range: from this heading to next heading at same-or-higher level
+     b. Count tokens in range
+     c. Generate anchor from title (lowercase, replace spaces with hyphens, strip punctuation)
+     d. Extract first 200 chars as text_preview
+  3. Apply tree thinning: if section token_count < min_tokens, merge into previous section
+  4. Output JSON array to stdout
+
+NOTES:
+  - Code block detection: track ``` delimiters, skip headings inside code blocks
+  - Anchor generation matches existing section-indexing anchor logic
+  - text_preview is for the LLM to generate summaries without reading the full file
+```
+
+**Source-scanner integration:**
+
+After file discovery (Phase 2a), the source-scanner:
+
+1. Runs `detect_large_files.py` on the source.
+2. For each large file with `has_headings: true`:
+   - Runs `split_by_headings.py` on the file.
+   - Generates one parent entry for the file (with a high-level summary).
+   - Generates child entries for each split section (with `tier: section`, `parent` set to the file entry ID).
+   - LLM inference generates summary/tags/keywords for each child entry based on `text_preview`.
+3. For each large file with `has_headings: false`:
+   - Falls back to existing behavior: `size: large` flag + `grep_hint`.
+
+### Interaction with section indexing
+
+If `sections.enabled: true` is configured for the source AND a file is large, large-node splitting takes priority for that file (since it produces section entries with the same schema). The per-source section config still applies to non-large files.
+
+If `sections.enabled: false` (or not configured), large-node splitting still runs for files exceeding the threshold. This means large files get automatic sub-entries even without explicit section indexing — section indexing is an opt-in for all files, large-node splitting is automatic for large files only.
+
+### Configuration
+
+New optional field in `config.yaml`:
+
+```yaml
+build:
+  large_file_threshold: 15000  # tokens, default 15000. Set 0 to disable.
+```
+
+### What changes in existing code
+
+- Source-scanner agent (`agents/source-scanner.md`): Add "Step 1b: Detect and split large files" after file discovery, before per-file metadata generation.
+- Build skill: No direct changes — the source-scanner returns additional section entries in its report, which the build skill processes normally.
+- `lib/corpus/patterns/scanning.md`: Document large-file splitting as a scanning strategy.
+- `config.yaml` template: Add `build.large_file_threshold` field.
+- Existing `size: large` and `grep_hint` behavior: Preserved as fallback for files without heading structure.
+
+---
+
+## Algorithm 5: Structure-Aware Chunking
+
+**Phase:** 2d (deep chunking), upgrades `chunk.py` markdown strategy
+**Type:** Entirely deterministic
+
+### Problem
+
+`chunk.py`'s markdown strategy uses boundary scoring based on heading weight, blank lines, and paragraph breaks, with a target of ~900 tokens per chunk. This produces chunks that can split mid-section, losing structural context. PageIndex preserves document hierarchy by using natural section boundaries as primary split points, only subdividing when a section exceeds the token limit.
+
+### Solution
+
+**Script:** `lib/corpus/scripts/chunk_with_overlap.py`
+
+This is a new chunking strategy, not a replacement for `chunk.py`. It can be invoked as an alternative strategy or integrated into `chunk.py` as a new `--strategy headings` option.
+
+```
+INTERFACE:
+  Input:
+    --file PATH               (path to markdown file)
+    --max-tokens N            (maximum tokens per chunk, default 900)
+    --overlap-tokens N        (overlap at chunk boundaries, default 100)
+    --min-level N             (minimum heading level for primary splits, default 2)
+    --json                    (output as JSON)
+  Output: JSON to stdout
+    [
+      {
+        "chunk_index": 0,
+        "line_start": 1,
+        "line_end": 45,
+        "token_count": 780,
+        "heading_context": "## Getting Started",
+        "overlap_prev": false,
+        "text": "## Getting Started\n\nThis guide walks you through..."
+      },
+      {
+        "chunk_index": 1,
+        "line_start": 42,
+        "line_end": 98,
+        "token_count": 850,
+        "heading_context": "## Getting Started > ### Installation",
+        "overlap_prev": true,
+        "text": "...previous section ending...\n### Installation\n\n..."
+      }
+    ]
+
+ALGORITHM:
+  1. Parse headings at min_level and deeper (reuse split_by_headings logic)
+  2. Build section tree with token counts
+  
+  3. For each section (depth-first):
+     if section.token_count <= max_tokens:
+       emit section as one chunk
+       set heading_context = ancestor heading chain ("## Parent > ### Child")
+     
+     else:
+       # Section too large — split at sub-headings first
+       if section has sub-headings:
+         recurse into sub-sections
+       else:
+         # No sub-headings — split at paragraph boundaries
+         paragraphs = split_on_blank_lines(section.text)
+         current_chunk = []
+         current_tokens = 0
+         
+         for each paragraph:
+           if current_tokens + paragraph_tokens > max_tokens:
+             emit current_chunk
+             # Start new chunk with overlap from end of previous
+             overlap = last_N_tokens(current_chunk, overlap_tokens)
+             current_chunk = [overlap, paragraph]
+             current_tokens = overlap_tokens + paragraph_tokens
+           else:
+             current_chunk.append(paragraph)
+             current_tokens += paragraph_tokens
+         
+         emit remaining current_chunk
+  
+  4. Each emitted chunk carries:
+     - heading_context: nearest ancestor heading chain
+     - overlap_prev: true if chunk starts with overlap from previous chunk
+     - line_start/line_end: original file line numbers
+
+HEADING CONTEXT FORMAT:
+  "## Data Modeling > ### Primary Keys > #### Composite Keys"
+  This gives each chunk the structural context that token-window chunking loses.
+  The heading_context is included in the chunk's embedding text by the embed pipeline.
+
+OVERLAP BEHAVIOR:
+  Overlap only occurs when a section is split at paragraph boundaries (not between
+  heading-bounded sections). If section A ends and section B begins, there is no overlap
+  — the heading boundary is a clean break. Overlap only handles the case where a single
+  large section without sub-headings must be split mid-content.
+```
+
+### Integration with existing chunk.py
+
+Two options (recommend Option A):
+
+**Option A: New strategy in chunk.py.** Add `--strategy headings` to `chunk.py` that delegates to the algorithm above. The existing `markdown`, `transcript`, `code`, `paragraph` strategies are unchanged. The source-scanner chooses `headings` strategy when the file has consistent heading structure, falls back to `markdown` otherwise.
+
+**Option B: Separate script.** Ship as `chunk_with_overlap.py` alongside `chunk.py`. The source-scanner calls whichever is appropriate.
+
+Option A is cleaner — one entry point, one JSON output format, strategy selection is the only change.
+
+### Configuration
+
+The chunking config gains a new strategy option:
+
+```yaml
+sources:
+  - id: docs
+    chunking:
+      enabled: true
+      strategy: headings   # NEW. Options: headings (new default), markdown, transcript, code, paragraph
+      target_tokens: 900
+      overlap_tokens: 100
+```
+
+If `strategy` is not set, default to `headings` for sources where `detect_nav.py` or heading analysis indicates consistent heading structure, otherwise fall back to `markdown`.
+
+### Embedding integration
+
+The `heading_context` field is prepended to chunk text when generating embeddings:
+
+```
+Current:  "passage: {chunk_text}"
+Proposed: "passage: {heading_context} | {chunk_text}"
+```
+
+This means a chunk from "## Data Modeling > ### Primary Keys" gets embedded with that structural context, improving retrieval for queries about "primary keys in data modeling" even when the chunk text doesn't repeat those terms.
+
+### What changes in existing code
+
+- `lib/corpus/scripts/chunk.py`: Add `headings` strategy option. Internal refactor to call heading-aware splitting logic.
+- Source-scanner agent (`agents/source-scanner.md`): Default to `headings` strategy when heading structure is detected.
+- `lib/corpus/scripts/embed.py`: Prepend `heading_context` to chunk embedding text when available.
+- `config.yaml` template: Add `strategy` field to chunking config.
+
+---
+
+## Cross-Cutting Concerns
+
+### Script dependencies
+
+All new scripts require only Python 3 stdlib. PyYAML is used by `detect_nav.py`, `verify_entries.py`, and `thin_sections.py` but is already an optional dependency. Token counting uses fastembed tokenizer if available, otherwise word-count approximation.
+
+No new required dependencies.
+
+### Error handling
+
+All scripts:
+- Exit 0 on success with JSON to stdout.
+- Exit 1 on error with error message to stderr.
+- Never modify files without explicit `--in-place` or `--output` flag (except `thin_sections.py` which modifies index.yaml in-place, with `--dry-run` option).
+
+### Backward compatibility
+
+- Existing `config.yaml` files work without changes. All new fields are optional with sensible defaults.
+- Existing corpora do not need rebuilding. New features activate only when configured or when thresholds are exceeded.
+- `min_content_lines` in section config is deprecated but still honored. `min_section_tokens` takes precedence if both are set.
+
+### Updated cross-cutting concerns table
+
+New rows for CLAUDE.md cross-cutting concerns:
+
+| Feature | Relevant Skills | What to Check |
+|---|---|---|
+| Nav detection | source-scanner, build, add-source | `detect_nav.py` called before glob scan, coverage threshold logic |
+| Verification loop | build, refresh | `verify_entries.py` + LLM verification, config flag |
+| Tree thinning | build, enhance, refresh | `thin_sections.py` post-processing, `min_section_tokens` config |
+| Large-node splitting | source-scanner, build | `detect_large_files.py` + `split_by_headings.py`, interaction with section indexing |
+| Structure-aware chunking | build, source-scanner, navigate | `headings` strategy in `chunk.py`, `heading_context` in embeddings |
+
+## Acceptance Criteria
+
+### Algorithm 1: Nav Detection
+- [ ] `detect_nav.py` parses `mkdocs.yml` nav, `_sidebar.md`, and `SUMMARY.md` into hierarchy JSON.
+- [ ] Coverage percentage is calculated correctly (resolved files / total files).
+- [ ] Source-scanner uses nav skeleton when coverage >= 80%, falls back otherwise.
+- [ ] Files outside the nav are still scanned and included.
+
+### Algorithm 2: Verification Loop
+- [ ] `verify_entries.py` extracts content previews for specified entries.
+- [ ] Build skill runs verification after index generation (when `verify_on_build: true`).
+- [ ] Inaccurate entries are presented to user with option to regenerate.
+- [ ] Refresh skill can call verification after updating stale entries.
+
+### Algorithm 3: Tree Thinning
+- [ ] `thin_sections.py` merges sections below `min_section_tokens` bottom-up.
+- [ ] Merged sections preserve keywords from removed children.
+- [ ] Never merges across different source files.
+- [ ] `--dry-run` mode shows what would be merged without modifying files.
+- [ ] Existing `min_content_lines` config still works when `min_section_tokens` is not set.
+
+### Algorithm 4: Large-Node Splitting
+- [ ] `detect_large_files.py` identifies files exceeding token threshold.
+- [ ] `split_by_headings.py` produces section entries with correct line ranges and anchors.
+- [ ] Source-scanner generates parent + child entries for large files with headings.
+- [ ] Files without headings fall back to existing `size: large` + `grep_hint`.
+- [ ] Large-node splitting and section indexing coexist without duplicate entries.
+
+### Algorithm 5: Structure-Aware Chunking
+- [ ] `chunk.py` gains `--strategy headings` option.
+- [ ] Heading-bounded sections that fit in `max_tokens` are emitted as single chunks.
+- [ ] Sections exceeding `max_tokens` are split at paragraph boundaries with overlap.
+- [ ] Each chunk carries `heading_context` (ancestor heading chain).
+- [ ] `embed.py` prepends `heading_context` to chunk embedding text.
+- [ ] Existing chunking strategies (`markdown`, `transcript`, `code`, `paragraph`) are unchanged.
+
+### Integration
+- [ ] All scripts exit 0 with JSON stdout on success, exit 1 with stderr on error.
+- [ ] No new required dependencies (PyYAML and fastembed remain optional).
+- [ ] Existing corpora continue to work without rebuilding.
+- [ ] CLAUDE.md cross-cutting concerns table is updated.

--- a/lib/corpus/scripts/chunk.py
+++ b/lib/corpus/scripts/chunk.py
@@ -44,6 +44,7 @@ BOUNDARY_SCORES = {
         "double_newline": 50,
         "single_newline": 10,
     },
+    "headings": {"heading": 100, "blank_line": 20},
 }
 
 STRATEGY_DEFAULTS = {
@@ -51,6 +52,7 @@ STRATEGY_DEFAULTS = {
     "transcript": {"target_tokens": 900, "overlap_tokens": 100},
     "code": {"target_tokens": 600, "overlap_tokens": 50},
     "paragraph": {"target_tokens": 900, "overlap_tokens": 100},
+    "headings": {"target_tokens": 900, "overlap_tokens": 100},
 }
 
 HEADING_RE = re.compile(r"^#{1,6}\s+")
@@ -101,6 +103,92 @@ def score_line(line: str, strategy: str) -> int:
     return 0
 
 
+def _chunk_paragraphs(lines, target_tokens, overlap_tokens, heading_context, start_line=1):
+    """Split lines into chunks at paragraph boundaries with overlap."""
+    chunks = []
+    current_lines = []
+    current_tokens = 0
+    chunk_start = start_line
+
+    for i, line in enumerate(lines):
+        line_tokens = max(1, int(len(line.split()) * TOKENS_PER_WORD)) if line.strip() else 1
+        if current_tokens + line_tokens > target_tokens and current_lines:
+            chunk_text_str = "\n".join(current_lines)
+            chunks.append({
+                "text": chunk_text_str,
+                "line_range": [chunk_start, start_line + i - 1],
+                "chunk_index": len(chunks),
+                "overlap_prev": len(chunks) > 0 and overlap_tokens > 0,
+                "heading_context": heading_context,
+            })
+            if overlap_tokens > 0:
+                overlap_lines = []
+                overlap_count = 0
+                for prev_line in reversed(current_lines):
+                    prev_tokens = max(1, int(len(prev_line.split()) * TOKENS_PER_WORD)) if prev_line.strip() else 1
+                    overlap_count += prev_tokens
+                    overlap_lines.insert(0, prev_line)
+                    if overlap_count >= overlap_tokens:
+                        break
+                current_lines = overlap_lines
+                current_tokens = overlap_count
+                chunk_start = start_line + i - len(overlap_lines)
+            else:
+                current_lines = []
+                current_tokens = 0
+                chunk_start = start_line + i
+        current_lines.append(line)
+        current_tokens += line_tokens
+
+    if current_lines:
+        chunks.append({
+            "text": "\n".join(current_lines),
+            "line_range": [chunk_start, start_line + len(lines) - 1],
+            "chunk_index": len(chunks),
+            "overlap_prev": len(chunks) > 0 and overlap_tokens > 0,
+            "heading_context": heading_context,
+        })
+    return chunks
+
+
+def _chunk_by_headings(text, target_tokens, overlap_tokens):
+    """Chunk by heading sections, splitting large sections at paragraphs."""
+    from split_by_headings import split_by_headings as _split
+
+    sections = _split(text, min_level=1, max_level=6, min_tokens=0)
+    lines = text.split("\n")
+
+    if not sections:
+        # No headings — fall back to paragraph-based splitting
+        return _chunk_paragraphs(lines, target_tokens, overlap_tokens, "", start_line=1)
+
+    chunks = []
+    for section in sections:
+        start = section["line_start"] - 1  # 0-indexed
+        end = section["line_end"]
+        section_lines = lines[start:end]
+        section_tokens = estimate_tokens("\n".join(section_lines))
+        heading_context = f"{'#' * section['level']} {section['title']}"
+
+        if section_tokens <= target_tokens:
+            chunks.append({
+                "text": "\n".join(section_lines),
+                "line_range": [section["line_start"], section["line_end"]],
+                "chunk_index": len(chunks),
+                "overlap_prev": False,
+                "heading_context": heading_context,
+            })
+        else:
+            sub_chunks = _chunk_paragraphs(
+                section_lines, target_tokens, overlap_tokens,
+                heading_context, start_line=section["line_start"],
+            )
+            for sc in sub_chunks:
+                sc["chunk_index"] = len(chunks)
+                chunks.append(sc)
+    return chunks
+
+
 def chunk_text(
     text: str,
     strategy: str = "markdown",
@@ -123,6 +211,9 @@ def chunk_text(
         target_tokens = defaults["target_tokens"]
     if overlap_tokens is None:
         overlap_tokens = defaults["overlap_tokens"]
+
+    if strategy == "headings":
+        return _chunk_by_headings(text, target_tokens, overlap_tokens)
 
     lines = text.split("\n")
     total_lines = len(lines)
@@ -221,7 +312,7 @@ def parse_args():
     parser.add_argument("file", help="Path to document file")
     parser.add_argument(
         "--strategy",
-        choices=["markdown", "transcript", "code", "paragraph"],
+        choices=["markdown", "transcript", "code", "paragraph", "headings"],
         default="markdown",
         help="Chunking strategy (default: markdown)",
     )

--- a/lib/corpus/scripts/detect_large_files.py
+++ b/lib/corpus/scripts/detect_large_files.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Detect markdown files exceeding a token threshold.
+
+Usage:
+  python3 detect_large_files.py --source-root <path> [--max-tokens 15000] [--paths <file>]
+
+Output: JSON array of {path, token_count, line_count, has_headings, heading_count, deepest_heading_level}.
+
+Exit codes:
+  0 - success
+  1 - invalid arguments
+  2 - python error
+"""
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from token_utils import estimate_tokens
+
+HEADING_RE = re.compile(r"^(#{1,6})\s+", re.MULTILINE)
+
+
+def detect_large_files(
+    source_root: str,
+    max_tokens: int = 15000,
+    paths: list[str] | None = None,
+) -> list[dict]:
+    root = Path(source_root)
+    result = []
+
+    if paths:
+        files = [root / p for p in paths]
+    else:
+        files = sorted(root.rglob("*.md")) + sorted(root.rglob("*.mdx"))
+
+    for file_path in files:
+        if not file_path.exists():
+            continue
+        text = file_path.read_text(errors="replace")
+        token_count = estimate_tokens(text)
+        if token_count <= max_tokens:
+            continue
+
+        headings = HEADING_RE.findall(text)
+        heading_count = len(headings)
+        deepest = max((len(h) for h in headings), default=0) if headings else 0
+
+        rel_path = str(file_path.relative_to(root))
+        result.append({
+            "path": rel_path, "token_count": token_count,
+            "line_count": text.count("\n") + 1,
+            "has_headings": heading_count > 0,
+            "heading_count": heading_count,
+            "deepest_heading_level": deepest,
+        })
+    return result
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Detect large markdown files")
+    parser.add_argument("--source-root", required=True, help="Path to source root")
+    parser.add_argument("--max-tokens", type=int, default=15000, help="Token threshold (default: 15000)")
+    parser.add_argument("--paths", default=None, help="File with paths to check (one per line)")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    paths = None
+    if args.paths:
+        paths = Path(args.paths).read_text().strip().splitlines()
+    result = detect_large_files(args.source_root, args.max_tokens, paths)
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception as e:
+        print(f"error: {e}", file=sys.stderr)
+        sys.exit(2)

--- a/lib/corpus/scripts/detect_nav.py
+++ b/lib/corpus/scripts/detect_nav.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Detect and parse documentation navigation structure.
+
+Usage:
+  python3 detect_nav.py --source-root <path>
+
+Scans for mkdocs.yml, _sidebar.md, SUMMARY.md, _toc.yml in priority order.
+Parses the first found into a hierarchy with coverage stats.
+
+Output: JSON to stdout with {found, nav_file, framework, hierarchy, coverage}.
+
+Exit codes:
+  0 - success (found or not found)
+  1 - invalid arguments
+  2 - python error
+"""
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+NAV_CANDIDATES = [
+    ("mkdocs.yml", "mkdocs", "yaml_nav"),
+    ("mkdocs.yaml", "mkdocs", "yaml_nav"),
+    ("_sidebar.md", "docsify", "sidebar_md"),
+    ("SUMMARY.md", "mdbook", "sidebar_md"),
+    ("src/SUMMARY.md", "mdbook", "sidebar_md"),
+    ("_toc.yml", "custom", "yaml_toc"),
+]
+
+LINK_RE = re.compile(r"^(\s*)-\s*\[([^\]]+)\]\(([^)]+)\)")
+
+
+def parse_mkdocs_nav(nav_file: Path, source_root: Path) -> list[dict]:
+    """Parse mkdocs.yml nav: key into hierarchy list."""
+    try:
+        import yaml
+    except ImportError:
+        return _parse_mkdocs_nav_regex(nav_file, source_root)
+
+    with open(nav_file) as f:
+        data = yaml.safe_load(f)
+
+    nav = data.get("nav") if isinstance(data, dict) else None
+    if not nav:
+        return []
+
+    return _walk_mkdocs_nav(nav, source_root, level=1)
+
+
+def _walk_mkdocs_nav(nav_items: list, source_root: Path, level: int) -> list[dict]:
+    result = []
+    for item in nav_items:
+        if isinstance(item, dict):
+            for title, value in item.items():
+                if isinstance(value, str):
+                    result.append({"title": title, "path": value, "level": level, "children": []})
+                elif isinstance(value, list):
+                    children = _walk_mkdocs_nav(value, source_root, level + 1)
+                    result.append({"title": title, "path": None, "level": level, "children": children})
+        elif isinstance(item, str):
+            result.append({"title": item, "path": item, "level": level, "children": []})
+    return result
+
+
+def _parse_mkdocs_nav_regex(nav_file: Path, source_root: Path) -> list[dict]:
+    text = nav_file.read_text()
+    in_nav = False
+    flat = []
+    min_indent = None
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("nav:"):
+            in_nav = True
+            continue
+        if in_nav:
+            if not line.startswith(" ") and not line.startswith("\t") and stripped:
+                break
+            # Match lines with format: "  - Title: path.md" or "  - Title:"
+            match = re.match(r"^(\s*)-\s+(.+?):\s*(.*?)$", line)
+            if match:
+                indent = len(match.group(1))
+                if min_indent is None:
+                    min_indent = indent
+                level = ((indent - min_indent) // 2) + 1
+                title = match.group(2).strip()
+                path = match.group(3).strip() if match.group(3).strip() else None
+                flat.append({"title": title, "path": path, "level": level, "children": []})
+    return _nest_by_level(flat)
+
+
+def parse_sidebar_md(sidebar_file: Path, source_root: Path) -> list[dict]:
+    text = sidebar_file.read_text()
+    flat = []
+    for line in text.splitlines():
+        match = LINK_RE.match(line)
+        if match:
+            indent = len(match.group(1))
+            level = (indent // 2) + 1
+            flat.append({"title": match.group(2).strip(), "path": match.group(3).strip(), "level": level, "children": []})
+    return _nest_by_level(flat)
+
+
+def _nest_by_level(flat: list[dict]) -> list[dict]:
+    if not flat:
+        return []
+    root = []
+    stack: list[dict] = []
+    for item in flat:
+        while stack and stack[-1]["level"] >= item["level"]:
+            stack.pop()
+        if stack:
+            stack[-1]["children"].append(item)
+        else:
+            root.append(item)
+        stack.append(item)
+    return root
+
+
+def _collect_paths(hierarchy: list[dict]) -> list[str]:
+    paths = []
+    for item in hierarchy:
+        if item.get("path"):
+            paths.append(item["path"])
+        paths.extend(_collect_paths(item.get("children", [])))
+    return paths
+
+
+def _count_md_files(source_root: Path) -> int:
+    count = 0
+    for ext in ("*.md", "*.mdx"):
+        count += len(list(source_root.rglob(ext)))
+    return count
+
+
+def detect_nav(source_root_str: str) -> dict:
+    source_root = Path(source_root_str)
+    empty_result = {
+        "found": False, "nav_file": None, "framework": None, "hierarchy": [],
+        "coverage": {"nav_entries": 0, "files_resolved": 0, "files_missing": 0, "total_md_files": _count_md_files(source_root) if source_root.is_dir() else 0, "coverage_pct": 0.0},
+    }
+    if not source_root.is_dir():
+        return empty_result
+
+    for filename, framework, parser_type in NAV_CANDIDATES:
+        nav_path = source_root / filename
+        if not nav_path.exists():
+            continue
+        if parser_type == "yaml_nav":
+            hierarchy = parse_mkdocs_nav(nav_path, source_root)
+        elif parser_type == "sidebar_md":
+            hierarchy = parse_sidebar_md(nav_path, source_root)
+        elif parser_type == "yaml_toc":
+            hierarchy = parse_mkdocs_nav(nav_path, source_root)
+        else:
+            continue
+        if not hierarchy:
+            continue
+
+        all_paths = _collect_paths(hierarchy)
+        resolved = sum(1 for p in all_paths if (source_root / p).exists())
+        missing = len(all_paths) - resolved
+        total_md = _count_md_files(source_root)
+        coverage_pct = round((resolved / total_md * 100) if total_md > 0 else 0.0, 1)
+
+        return {
+            "found": True, "nav_file": filename, "framework": framework, "hierarchy": hierarchy,
+            "coverage": {"nav_entries": len(all_paths), "files_resolved": resolved, "files_missing": missing, "total_md_files": total_md, "coverage_pct": coverage_pct},
+        }
+    return empty_result
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Detect documentation nav structure")
+    parser.add_argument("--source-root", required=True, help="Path to source root directory")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    result = detect_nav(args.source_root)
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception as e:
+        print(f"error: {e}", file=sys.stderr)
+        sys.exit(2)

--- a/lib/corpus/scripts/embed.py
+++ b/lib/corpus/scripts/embed.py
@@ -101,6 +101,7 @@ def load_chunks(input_path):
             "path": chunk["path"],
             "chunk_index": chunk["chunk_index"],
             "chunk_text": chunk["chunk_text"],
+            "heading_context": chunk.get("heading_context", ""),
             "line_range": chunk["line_range"],
             "overlap_prev": chunk.get("overlap_prev", False),
         })
@@ -185,10 +186,14 @@ def main_chunks(args):
         print("Warning: no chunks found in input file", file=sys.stderr)
         sys.exit(2)
 
-    # Generate embeddings — no passage: prefix for raw content
+    # Generate embeddings — prepend heading_context when available
     print(f"Embedding {len(items)} chunks with {MODEL_NAME}...", file=sys.stderr)
     model = TextEmbedding(model_name=MODEL_NAME)
-    texts = [item["chunk_text"] for item in items]
+    texts = []
+    for item in items:
+        heading_ctx = item.get("heading_context", "")
+        raw_text = item["chunk_text"]
+        texts.append(f"{heading_ctx} | {raw_text}" if heading_ctx else raw_text)
     embeddings = list(model.embed(texts))
 
     # Build PyArrow table with explicit schema

--- a/lib/corpus/scripts/split_by_headings.py
+++ b/lib/corpus/scripts/split_by_headings.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Split a markdown file into sections by heading structure.
+
+Usage:
+  python3 split_by_headings.py --file <path> [--min-level 2] [--max-level 4] [--min-tokens 200] [--json]
+
+Output: JSON array of sections with title, level, line_start, line_end, token_count, anchor, text_preview.
+
+Exit codes:
+  0 - success
+  1 - invalid arguments
+  2 - file not found
+  3 - python error
+"""
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from token_utils import estimate_tokens
+
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.+)$")
+CODE_FENCE_RE = re.compile(r"^```")
+ANCHOR_STRIP_RE = re.compile(r"[^\w\s-]")
+
+
+def _make_anchor(title: str) -> str:
+    anchor = title.lower().strip()
+    anchor = ANCHOR_STRIP_RE.sub("", anchor)
+    anchor = re.sub(r"\s+", "-", anchor)
+    anchor = anchor.strip("-")
+    return anchor
+
+
+def split_by_headings(
+    text: str,
+    min_level: int = 2,
+    max_level: int = 4,
+    min_tokens: int = 200,
+) -> list[dict]:
+    lines = text.split("\n")
+    in_code_block = False
+    raw_sections = []
+
+    for i, line in enumerate(lines):
+        if CODE_FENCE_RE.match(line.strip()):
+            in_code_block = not in_code_block
+            continue
+        if in_code_block:
+            continue
+        match = HEADING_RE.match(line)
+        if match:
+            level = len(match.group(1))
+            if min_level <= level <= max_level:
+                raw_sections.append({"title": match.group(2).strip(), "level": level, "line_start": i + 1})
+
+    if not raw_sections:
+        return []
+
+    # Find the last non-empty line
+    last_content_line = len(lines)
+    for i in range(len(lines) - 1, -1, -1):
+        if lines[i].strip():
+            last_content_line = i + 1
+            break
+
+    for idx, section in enumerate(raw_sections):
+        if idx + 1 < len(raw_sections):
+            section["line_end"] = raw_sections[idx + 1]["line_start"] - 1
+        else:
+            section["line_end"] = last_content_line
+
+        section_text = "\n".join(lines[section["line_start"] - 1 : section["line_end"]])
+        section["token_count"] = estimate_tokens(section_text)
+        section["anchor"] = _make_anchor(section["title"])
+        section["text_preview"] = section_text[:200]
+
+    if min_tokens > 0:
+        merged = []
+        for section in raw_sections:
+            if section["token_count"] < min_tokens and merged:
+                prev = merged[-1]
+                prev["line_end"] = section["line_end"]
+                prev_text = "\n".join(lines[prev["line_start"] - 1 : prev["line_end"]])
+                prev["token_count"] = estimate_tokens(prev_text)
+                prev["text_preview"] = prev_text[:200]
+            else:
+                merged.append(section)
+        raw_sections = merged
+
+    return raw_sections
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Split markdown file by headings")
+    parser.add_argument("--file", required=True, help="Path to markdown file")
+    parser.add_argument("--min-level", type=int, default=2, help="Min heading level (default: 2)")
+    parser.add_argument("--max-level", type=int, default=4, help="Max heading level (default: 4)")
+    parser.add_argument("--min-tokens", type=int, default=200, help="Min tokens per section (default: 200)")
+    parser.add_argument("--json", action="store_true", dest="json_output", help="Output as JSON")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    file_path = Path(args.file)
+    if not file_path.exists():
+        print(f"error: file not found: {args.file}", file=sys.stderr)
+        sys.exit(2)
+    text = file_path.read_text(errors="replace")
+    sections = split_by_headings(text, args.min_level, args.max_level, args.min_tokens)
+    if args.json_output:
+        print(json.dumps(sections, indent=2))
+    else:
+        for s in sections:
+            print(f"{s['anchor']}\tL{s['line_start']}-{s['line_end']}\t{s['token_count']} tokens\t{s['title']}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception as e:
+        print(f"error: {e}", file=sys.stderr)
+        sys.exit(3)

--- a/lib/corpus/scripts/tests/test_chunk_headings.py
+++ b/lib/corpus/scripts/tests/test_chunk_headings.py
@@ -1,0 +1,52 @@
+"""Tests for chunk.py headings strategy."""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+class TestHeadingsStrategy:
+    def test_sections_within_target_are_single_chunks(self):
+        from chunk import chunk_text
+        text = "## Section One\n\nShort content.\n\n## Section Two\n\nAnother short section.\n"
+        chunks = chunk_text(text, strategy="headings", target_tokens=100, overlap_tokens=10)
+        assert len(chunks) == 2
+        assert "heading_context" in chunks[0]
+        assert chunks[0]["heading_context"] == "## Section One"
+        assert chunks[1]["heading_context"] == "## Section Two"
+
+    def test_large_sections_split_at_paragraphs(self):
+        from chunk import chunk_text
+        text = "## Big Section\n\n"
+        for i in range(20):
+            text += f"Paragraph {i}. " * 20 + "\n\n"
+        chunks = chunk_text(text, strategy="headings", target_tokens=50, overlap_tokens=10)
+        assert len(chunks) > 1
+        for c in chunks:
+            assert c["heading_context"] == "## Big Section"
+
+    def test_no_overlap_at_heading_boundaries(self):
+        from chunk import chunk_text
+        text = "## First\n\nContent one.\n\n## Second\n\nContent two.\n"
+        chunks = chunk_text(text, strategy="headings", target_tokens=100, overlap_tokens=10)
+        if len(chunks) >= 2:
+            assert chunks[1].get("overlap_prev") is False
+
+    def test_overlap_on_paragraph_splits(self):
+        from chunk import chunk_text
+        text = "## Section\n\n"
+        for i in range(20):
+            text += f"Paragraph {i}. " * 20 + "\n\n"
+        chunks = chunk_text(text, strategy="headings", target_tokens=50, overlap_tokens=10)
+        if len(chunks) >= 2:
+            assert chunks[1].get("overlap_prev") is True
+
+    def test_no_headings_falls_back(self):
+        from chunk import chunk_text
+        text = "Just plain text.\n" * 50
+        chunks = chunk_text(text, strategy="headings", target_tokens=20, overlap_tokens=5)
+        assert len(chunks) >= 1
+        for c in chunks:
+            assert "heading_context" in c

--- a/lib/corpus/scripts/tests/test_detect_large_files.py
+++ b/lib/corpus/scripts/tests/test_detect_large_files.py
@@ -1,4 +1,6 @@
 """Tests for detect_large_files.py — large file detection."""
+import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -53,3 +55,25 @@ class TestDetectLargeFiles:
     def test_high_threshold_finds_nothing(self, docs_dir):
         result = detect_large_files(str(docs_dir), max_tokens=999999)
         assert result == []
+
+
+class TestDetectLargeFilesCLI:
+    def test_cli_json_output(self, docs_dir):
+        result = subprocess.run(
+            [sys.executable, str(Path(__file__).parent.parent / "detect_large_files.py"),
+             "--source-root", str(docs_dir), "--max-tokens", "50"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert len(data) >= 1
+
+    def test_cli_nonexistent_dir(self):
+        result = subprocess.run(
+            [sys.executable, str(Path(__file__).parent.parent / "detect_large_files.py"),
+             "--source-root", "/nonexistent"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert data == []

--- a/lib/corpus/scripts/tests/test_detect_large_files.py
+++ b/lib/corpus/scripts/tests/test_detect_large_files.py
@@ -1,0 +1,55 @@
+"""Tests for detect_large_files.py — large file detection."""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from detect_large_files import detect_large_files
+
+
+@pytest.fixture
+def docs_dir(tmp_path):
+    (tmp_path / "small.md").write_text("# Small\n\nJust a small file.\n")
+    large_content = "# Large File\n\n"
+    for i in range(20):
+        large_content += f"## Section {i}\n\n" + f"Content for section {i}. " * 10 + "\n\n"
+    (tmp_path / "large_with_headings.md").write_text(large_content)
+    plain_content = "Just a very long file.\n" * 100
+    (tmp_path / "large_plain.md").write_text(plain_content)
+    return tmp_path
+
+
+class TestDetectLargeFiles:
+    def test_detects_large_files(self, docs_dir):
+        result = detect_large_files(str(docs_dir), max_tokens=50)
+        paths = [r["path"] for r in result]
+        assert any("large_with_headings" in p for p in paths)
+        assert any("large_plain" in p for p in paths)
+
+    def test_ignores_small_files(self, docs_dir):
+        result = detect_large_files(str(docs_dir), max_tokens=50)
+        paths = [r["path"] for r in result]
+        assert not any("small" in p for p in paths)
+
+    def test_reports_heading_info(self, docs_dir):
+        result = detect_large_files(str(docs_dir), max_tokens=50)
+        with_headings = [r for r in result if "large_with_headings" in r["path"]]
+        assert len(with_headings) == 1
+        assert with_headings[0]["has_headings"] is True
+        assert with_headings[0]["heading_count"] >= 20
+
+    def test_no_headings_detected(self, docs_dir):
+        result = detect_large_files(str(docs_dir), max_tokens=50)
+        plain = [r for r in result if "large_plain" in r["path"]]
+        assert len(plain) == 1
+        assert plain[0]["has_headings"] is False
+
+    def test_empty_dir(self, tmp_path):
+        result = detect_large_files(str(tmp_path), max_tokens=50)
+        assert result == []
+
+    def test_high_threshold_finds_nothing(self, docs_dir):
+        result = detect_large_files(str(docs_dir), max_tokens=999999)
+        assert result == []

--- a/lib/corpus/scripts/tests/test_detect_nav.py
+++ b/lib/corpus/scripts/tests/test_detect_nav.py
@@ -1,0 +1,171 @@
+"""Tests for detect_nav.py — navigation structure detection.
+
+Unit tests (no external deps):
+  - MkDocs YAML nav parsing
+  - Docsify _sidebar.md parsing
+  - mdBook SUMMARY.md parsing
+  - Coverage calculation
+  - Missing files handling
+  - No nav file found
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from detect_nav import detect_nav, parse_mkdocs_nav, parse_sidebar_md
+
+
+class TestParseMkdocsNav:
+    """Parse mkdocs.yml nav: key into hierarchy."""
+
+    def test_simple_flat_nav(self, tmp_path):
+        mkdocs = tmp_path / "mkdocs.yml"
+        mkdocs.write_text(
+            "nav:\n"
+            "  - Home: index.md\n"
+            "  - Getting Started: getting-started.md\n"
+            "  - API Reference: api.md\n"
+        )
+        for name in ["index.md", "getting-started.md", "api.md"]:
+            (tmp_path / name).write_text(f"# {name}")
+
+        result = parse_mkdocs_nav(mkdocs, tmp_path)
+        assert len(result) == 3
+        assert result[0]["title"] == "Home"
+        assert result[0]["path"] == "index.md"
+        assert result[0]["level"] == 1
+
+    def test_nested_nav(self, tmp_path):
+        mkdocs = tmp_path / "mkdocs.yml"
+        mkdocs.write_text(
+            "nav:\n"
+            "  - Home: index.md\n"
+            "  - Guide:\n"
+            "    - Install: guide/install.md\n"
+            "    - Usage: guide/usage.md\n"
+        )
+        (tmp_path / "index.md").write_text("# Home")
+        (tmp_path / "guide").mkdir()
+        (tmp_path / "guide" / "install.md").write_text("# Install")
+        (tmp_path / "guide" / "usage.md").write_text("# Usage")
+
+        result = parse_mkdocs_nav(mkdocs, tmp_path)
+        assert len(result) == 2
+        guide = result[1]
+        assert guide["title"] == "Guide"
+        assert len(guide["children"]) == 2
+        assert guide["children"][0]["level"] == 2
+
+    def test_missing_files_still_parsed(self, tmp_path):
+        mkdocs = tmp_path / "mkdocs.yml"
+        mkdocs.write_text(
+            "nav:\n"
+            "  - Exists: exists.md\n"
+            "  - Missing: missing.md\n"
+        )
+        (tmp_path / "exists.md").write_text("# Exists")
+
+        result = parse_mkdocs_nav(mkdocs, tmp_path)
+        assert len(result) == 2
+
+
+class TestParseSidebarMd:
+    """Parse _sidebar.md / SUMMARY.md link-list format."""
+
+    def test_flat_sidebar(self, tmp_path):
+        sidebar = tmp_path / "_sidebar.md"
+        sidebar.write_text(
+            "- [Home](index.md)\n"
+            "- [Guide](guide.md)\n"
+            "- [API](api.md)\n"
+        )
+        for name in ["index.md", "guide.md", "api.md"]:
+            (tmp_path / name).write_text(f"# {name}")
+
+        result = parse_sidebar_md(sidebar, tmp_path)
+        assert len(result) == 3
+        assert result[0]["title"] == "Home"
+        assert result[0]["path"] == "index.md"
+
+    def test_nested_sidebar(self, tmp_path):
+        sidebar = tmp_path / "SUMMARY.md"
+        sidebar.write_text(
+            "- [Introduction](intro.md)\n"
+            "  - [Install](install.md)\n"
+            "  - [Config](config.md)\n"
+            "- [Advanced](advanced.md)\n"
+        )
+        for name in ["intro.md", "install.md", "config.md", "advanced.md"]:
+            (tmp_path / name).write_text(f"# {name}")
+
+        result = parse_sidebar_md(sidebar, tmp_path)
+        assert len(result) == 2
+        assert len(result[0]["children"]) == 2
+        assert result[0]["children"][0]["level"] == 2
+
+
+class TestDetectNav:
+    """End-to-end nav detection."""
+
+    def test_no_nav_file(self, tmp_path):
+        (tmp_path / "readme.md").write_text("# Hello")
+        result = detect_nav(str(tmp_path))
+        assert result["found"] is False
+        assert result["hierarchy"] == []
+
+    def test_mkdocs_detected(self, tmp_path):
+        mkdocs = tmp_path / "mkdocs.yml"
+        mkdocs.write_text(
+            "site_name: Test\n"
+            "nav:\n"
+            "  - Home: index.md\n"
+            "  - About: about.md\n"
+        )
+        (tmp_path / "index.md").write_text("# Home")
+        (tmp_path / "about.md").write_text("# About")
+
+        result = detect_nav(str(tmp_path))
+        assert result["found"] is True
+        assert result["nav_file"] == "mkdocs.yml"
+        assert result["framework"] == "mkdocs"
+        assert len(result["hierarchy"]) == 2
+
+    def test_coverage_calculation(self, tmp_path):
+        mkdocs = tmp_path / "mkdocs.yml"
+        mkdocs.write_text(
+            "nav:\n"
+            "  - Home: index.md\n"
+            "  - Missing: missing.md\n"
+        )
+        (tmp_path / "index.md").write_text("# Home")
+        (tmp_path / "extra.md").write_text("# Extra")
+
+        result = detect_nav(str(tmp_path))
+        assert result["coverage"]["nav_entries"] == 2
+        assert result["coverage"]["files_resolved"] == 1
+        assert result["coverage"]["files_missing"] == 1
+        assert result["coverage"]["total_md_files"] == 2
+        assert result["coverage"]["coverage_pct"] == 50.0
+
+    def test_sidebar_fallback(self, tmp_path):
+        sidebar = tmp_path / "_sidebar.md"
+        sidebar.write_text("- [Home](index.md)\n")
+        (tmp_path / "index.md").write_text("# Home")
+
+        result = detect_nav(str(tmp_path))
+        assert result["found"] is True
+        assert result["framework"] == "docsify"
+
+    def test_summary_md_detected(self, tmp_path):
+        summary = tmp_path / "SUMMARY.md"
+        summary.write_text("- [Intro](intro.md)\n")
+        (tmp_path / "intro.md").write_text("# Intro")
+
+        result = detect_nav(str(tmp_path))
+        assert result["found"] is True
+        assert result["framework"] in ("mdbook", "gitbook")

--- a/lib/corpus/scripts/tests/test_detect_nav.py
+++ b/lib/corpus/scripts/tests/test_detect_nav.py
@@ -10,6 +10,7 @@ Unit tests (no external deps):
 """
 import json
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -169,3 +170,37 @@ class TestDetectNav:
         result = detect_nav(str(tmp_path))
         assert result["found"] is True
         assert result["framework"] in ("mdbook", "gitbook")
+
+
+class TestDetectNavCLI:
+    """CLI integration tests."""
+
+    def test_cli_valid_source(self, tmp_path):
+        mkdocs = tmp_path / "mkdocs.yml"
+        mkdocs.write_text("nav:\n  - Home: index.md\n")
+        (tmp_path / "index.md").write_text("# Home")
+        result = subprocess.run(
+            [sys.executable, str(Path(__file__).parent.parent / "detect_nav.py"),
+             "--source-root", str(tmp_path)],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert data["found"] is True
+
+    def test_cli_nonexistent_dir(self):
+        result = subprocess.run(
+            [sys.executable, str(Path(__file__).parent.parent / "detect_nav.py"),
+             "--source-root", "/nonexistent/path"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0  # not found is not an error
+        data = json.loads(result.stdout)
+        assert data["found"] is False
+
+    def test_cli_missing_arg(self):
+        result = subprocess.run(
+            [sys.executable, str(Path(__file__).parent.parent / "detect_nav.py")],
+            capture_output=True, text=True,
+        )
+        assert result.returncode != 0

--- a/lib/corpus/scripts/tests/test_embed.py
+++ b/lib/corpus/scripts/tests/test_embed.py
@@ -171,17 +171,6 @@ class TestErrorHandling:
 # --- Integration Tests (require fastembed + lancedb) ---
 
 
-def deps_available():
-    """Check if fastembed and lancedb are installed."""
-    try:
-        import fastembed  # noqa: F401
-        import lancedb  # noqa: F401
-        return True
-    except ImportError:
-        return False
-
-
-@pytest.mark.skipif(not deps_available(), reason="fastembed/lancedb not installed")
 class TestEmbeddingPipeline:
     """End-to-end tests requiring fastembed + lancedb."""
 
@@ -336,7 +325,6 @@ class TestChunkMode:
         assert result.returncode == 2
 
 
-@pytest.mark.skipif(not deps_available(), reason="fastembed/lancedb not installed")
 class TestChunkEmbeddingPipeline:
     """End-to-end tests for chunk embedding."""
 

--- a/lib/corpus/scripts/tests/test_embed.py
+++ b/lib/corpus/scripts/tests/test_embed.py
@@ -387,5 +387,124 @@ class TestChunkEmbeddingPipeline:
         assert output_json["embedded"] == 3
 
 
+class TestHeadingContextEmbedding:
+    """Tests for heading_context prepend in chunk embeddings."""
+
+    @pytest.fixture
+    def chunks_with_context(self, tmp_path):
+        """Create chunks JSON with heading_context fields."""
+        chunks = [
+            {
+                "id": "src:file.md#chunk-0",
+                "parent": "src:file.md",
+                "source": "src",
+                "path": "file.md",
+                "chunk_index": 0,
+                "chunk_text": "Install the package using pip.",
+                "heading_context": "## Getting Started > ### Installation",
+                "line_range": [1, 5],
+                "overlap_prev": False,
+            },
+            {
+                "id": "src:file.md#chunk-1",
+                "parent": "src:file.md",
+                "source": "src",
+                "path": "file.md",
+                "chunk_index": 1,
+                "chunk_text": "Configure the settings file.",
+                "heading_context": "",
+                "line_range": [6, 10],
+                "overlap_prev": False,
+            },
+        ]
+        path = tmp_path / "chunks_ctx.json"
+        path.write_text(json.dumps(chunks))
+        return path
+
+    @pytest.fixture
+    def chunks_without_context(self, tmp_path):
+        """Create chunks JSON without heading_context fields."""
+        chunks = [
+            {
+                "id": "src:file.md#chunk-0",
+                "parent": "src:file.md",
+                "source": "src",
+                "path": "file.md",
+                "chunk_index": 0,
+                "chunk_text": "Install the package using pip.",
+                "line_range": [1, 5],
+                "overlap_prev": False,
+            },
+        ]
+        path = tmp_path / "chunks_no_ctx.json"
+        path.write_text(json.dumps(chunks))
+        return path
+
+    def test_heading_context_produces_different_embeddings(self, chunks_with_context, chunks_without_context, tmp_path):
+        """Chunks with heading_context should embed differently than without."""
+        script = str(Path(__file__).parent.parent / "embed.py")
+
+        # Embed with context
+        out_ctx = tmp_path / "with_ctx.lance"
+        r1 = subprocess.run(
+            [sys.executable, script, "--mode", "chunks", str(chunks_with_context), str(out_ctx)],
+            capture_output=True, text=True,
+        )
+        assert r1.returncode == 0, f"Failed: {r1.stderr}"
+
+        # Embed without context
+        out_no_ctx = tmp_path / "no_ctx.lance"
+        r2 = subprocess.run(
+            [sys.executable, script, "--mode", "chunks", str(chunks_without_context), str(out_no_ctx)],
+            capture_output=True, text=True,
+        )
+        assert r2.returncode == 0, f"Failed: {r2.stderr}"
+
+        # Compare vectors — they should differ since heading_context was prepended
+        import lancedb
+        db_ctx = lancedb.connect(str(out_ctx))
+        db_no_ctx = lancedb.connect(str(out_no_ctx))
+        tbl_ctx = db_ctx.open_table("chunks")
+        tbl_no_ctx = db_no_ctx.open_table("chunks")
+
+        vec_ctx = tbl_ctx.to_pandas().iloc[0]["vector"]
+        vec_no_ctx = tbl_no_ctx.to_pandas().iloc[0]["vector"]
+
+        # Same chunk_text but different heading_context should produce different vectors
+        assert list(vec_ctx) != list(vec_no_ctx)
+
+    def test_empty_heading_context_backward_compatible(self, chunks_without_context, tmp_path):
+        """Chunks without heading_context field should embed normally."""
+        script = str(Path(__file__).parent.parent / "embed.py")
+        output = tmp_path / "compat.lance"
+        result = subprocess.run(
+            [sys.executable, script, "--mode", "chunks", str(chunks_without_context), str(output)],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, f"Failed: {result.stderr}"
+
+        import lancedb
+        db = lancedb.connect(str(output))
+        tbl = db.open_table("chunks")
+        df = tbl.to_pandas()
+        assert len(df) == 1
+        assert df.iloc[0]["id"] == "src:file.md#chunk-0"
+
+    def test_load_chunks_preserves_heading_context(self, chunks_with_context):
+        """load_chunks should include heading_context in items."""
+        sys.path.insert(0, str(Path(SCRIPT).parent))
+        from embed import load_chunks
+        items = load_chunks(str(chunks_with_context))
+        assert items[0]["heading_context"] == "## Getting Started > ### Installation"
+        assert items[1]["heading_context"] == ""
+
+    def test_load_chunks_defaults_missing_context(self, chunks_without_context):
+        """load_chunks should default heading_context to empty string when missing."""
+        sys.path.insert(0, str(Path(SCRIPT).parent))
+        from embed import load_chunks
+        items = load_chunks(str(chunks_without_context))
+        assert items[0]["heading_context"] == ""
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/lib/corpus/scripts/tests/test_pipeline.py
+++ b/lib/corpus/scripts/tests/test_pipeline.py
@@ -1,0 +1,125 @@
+"""Integration tests for cross-script pipelines.
+
+Tests that scripts compose correctly when used in sequence,
+as the source-scanner agent would use them.
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPTS_DIR = Path(__file__).parent.parent
+
+
+class TestLargeFileSplittingPipeline:
+    """detect_large_files → split_by_headings pipeline."""
+
+    @pytest.fixture
+    def source_with_large_file(self, tmp_path):
+        """Create a source directory with one large file and one small file."""
+        # Large file with headings (~500 words)
+        large = "# API Reference\n\n"
+        for i in range(15):
+            large += f"## Method {i}\n\n"
+            large += f"Description of method {i}. " * 20 + "\n\n"
+            large += f"### Parameters\n\nParam details for method {i}. " * 10 + "\n\n"
+        (tmp_path / "api.md").write_text(large)
+
+        # Small file
+        (tmp_path / "readme.md").write_text("# README\n\nShort file.\n")
+        return tmp_path
+
+    def test_detect_then_split(self, source_with_large_file):
+        """detect_large_files finds the file, split_by_headings splits it."""
+        # Step 1: detect large files
+        r1 = subprocess.run(
+            [sys.executable, str(SCRIPTS_DIR / "detect_large_files.py"),
+             "--source-root", str(source_with_large_file), "--max-tokens", "100"],
+            capture_output=True, text=True,
+        )
+        assert r1.returncode == 0
+        large_files = json.loads(r1.stdout)
+        assert len(large_files) >= 1
+
+        # Find the api.md entry
+        api_entry = [f for f in large_files if "api.md" in f["path"]]
+        assert len(api_entry) == 1
+        assert api_entry[0]["has_headings"] is True
+
+        # Step 2: split the large file by headings
+        api_path = source_with_large_file / api_entry[0]["path"]
+        r2 = subprocess.run(
+            [sys.executable, str(SCRIPTS_DIR / "split_by_headings.py"),
+             "--file", str(api_path), "--min-tokens", "0", "--json"],
+            capture_output=True, text=True,
+        )
+        assert r2.returncode == 0
+        sections = json.loads(r2.stdout)
+        assert len(sections) >= 10  # should have many sections
+
+        # Verify section structure
+        for section in sections:
+            assert "title" in section
+            assert "line_start" in section
+            assert "line_end" in section
+            assert "anchor" in section
+            assert section["line_start"] <= section["line_end"]
+
+    def test_small_files_not_split(self, source_with_large_file):
+        """Small files should not appear in detect_large_files output."""
+        r = subprocess.run(
+            [sys.executable, str(SCRIPTS_DIR / "detect_large_files.py"),
+             "--source-root", str(source_with_large_file), "--max-tokens", "100"],
+            capture_output=True, text=True,
+        )
+        large_files = json.loads(r.stdout)
+        paths = [f["path"] for f in large_files]
+        assert not any("readme" in p.lower() for p in paths)
+
+    def test_section_line_ranges_cover_file(self, source_with_large_file):
+        """Sections from split_by_headings should not have gaps."""
+        api_path = source_with_large_file / "api.md"
+        r = subprocess.run(
+            [sys.executable, str(SCRIPTS_DIR / "split_by_headings.py"),
+             "--file", str(api_path), "--min-level", "2", "--min-tokens", "0", "--json"],
+            capture_output=True, text=True,
+        )
+        sections = json.loads(r.stdout)
+        if len(sections) >= 2:
+            for i in range(len(sections) - 1):
+                # Next section starts at or after current section ends
+                assert sections[i + 1]["line_start"] == sections[i]["line_end"] + 1
+
+
+class TestNavDetectToScanPipeline:
+    """detect_nav → file scanning (simulated)."""
+
+    def test_nav_hierarchy_paths_are_resolvable(self, tmp_path):
+        """Paths in nav hierarchy should point to real files."""
+        mkdocs = tmp_path / "mkdocs.yml"
+        mkdocs.write_text(
+            "nav:\n"
+            "  - Home: index.md\n"
+            "  - Guide: guide/start.md\n"
+        )
+        (tmp_path / "index.md").write_text("# Home")
+        guide = tmp_path / "guide"
+        guide.mkdir()
+        (guide / "start.md").write_text("# Guide")
+
+        r = subprocess.run(
+            [sys.executable, str(SCRIPTS_DIR / "detect_nav.py"),
+             "--source-root", str(tmp_path)],
+            capture_output=True, text=True,
+        )
+        assert r.returncode == 0
+        result = json.loads(r.stdout)
+        assert result["found"] is True
+
+        # All resolved paths should exist
+        for entry in result["hierarchy"]:
+            if entry.get("path"):
+                assert (tmp_path / entry["path"]).exists()

--- a/lib/corpus/scripts/tests/test_search.py
+++ b/lib/corpus/scripts/tests/test_search.py
@@ -53,15 +53,6 @@ meta:
     return path
 
 
-def deps_available():
-    try:
-        import fastembed  # noqa: F401
-        import lancedb  # noqa: F401
-        return True
-    except ImportError:
-        return False
-
-
 @pytest.fixture
 def embedded_dataset(sample_index_yaml, tmp_path):
     """Build a Lance dataset from sample data. Requires fastembed + lancedb."""
@@ -104,7 +95,6 @@ class TestErrorHandling:
 # --- Integration Tests (require fastembed + lancedb) ---
 
 
-@pytest.mark.skipif(not deps_available(), reason="fastembed/lancedb not installed")
 class TestSearchPipeline:
 
     def test_basic_search_returns_results(self, embedded_dataset):
@@ -325,7 +315,6 @@ class TestHybridSearch:
 
         return tmp_path / "chunks.lance"
 
-    @pytest.mark.skipif(not deps_available(), reason="fastembed/lancedb not installed")
     def test_hybrid_search_returns_results(self, chunk_dataset):
         """--hybrid with --table chunks returns results using FTS+vector."""
         result = subprocess.run(
@@ -339,7 +328,6 @@ class TestHybridSearch:
         assert len(results) > 0
         assert results[0]["id"] == "src:file.md#chunk-0"
 
-    @pytest.mark.skipif(not deps_available(), reason="fastembed/lancedb not installed")
     def test_hybrid_returns_extra_columns(self, chunk_dataset):
         """--hybrid with --select returns requested columns."""
         result = subprocess.run(

--- a/lib/corpus/scripts/tests/test_split_by_headings.py
+++ b/lib/corpus/scripts/tests/test_split_by_headings.py
@@ -1,4 +1,6 @@
 """Tests for split_by_headings.py — heading-based file splitting."""
+import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -68,3 +70,37 @@ class TestSplitByHeadings:
         result = split_by_headings(text, min_level=2, max_level=4, min_tokens=0)
         assert "text_preview" in result[0]
         assert "First line" in result[0]["text_preview"]
+
+
+class TestSplitByHeadingsCLI:
+    def test_cli_json_output(self, tmp_path):
+        md = tmp_path / "test.md"
+        md.write_text("## Section\nContent.\n")
+        result = subprocess.run(
+            [sys.executable, str(Path(__file__).parent.parent / "split_by_headings.py"),
+             "--file", str(md), "--json", "--min-tokens", "0"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert len(data) == 1
+
+    def test_cli_missing_file(self):
+        result = subprocess.run(
+            [sys.executable, str(Path(__file__).parent.parent / "split_by_headings.py"),
+             "--file", "/nonexistent.md", "--json"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 2
+
+    def test_cli_tab_output(self, tmp_path):
+        md = tmp_path / "test.md"
+        md.write_text("## First\nContent.\n\n## Second\nMore.\n")
+        result = subprocess.run(
+            [sys.executable, str(Path(__file__).parent.parent / "split_by_headings.py"),
+             "--file", str(md), "--min-tokens", "0"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        assert "first" in result.stdout  # anchor
+        assert "second" in result.stdout

--- a/lib/corpus/scripts/tests/test_split_by_headings.py
+++ b/lib/corpus/scripts/tests/test_split_by_headings.py
@@ -1,0 +1,70 @@
+"""Tests for split_by_headings.py — heading-based file splitting."""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from split_by_headings import split_by_headings
+
+
+class TestSplitByHeadings:
+    def test_basic_split(self):
+        text = (
+            "# Title\n\nIntro paragraph.\n\n"
+            "## Section One\n\nContent for section one.\nMore content here.\n\n"
+            "## Section Two\n\nContent for section two.\n"
+        )
+        result = split_by_headings(text, min_level=2, max_level=4, min_tokens=0)
+        assert len(result) == 2
+        assert result[0]["title"] == "Section One"
+        assert result[1]["title"] == "Section Two"
+
+    def test_line_ranges(self):
+        text = "## First\nLine 2\nLine 3\n\n## Second\nLine 6\n"
+        result = split_by_headings(text, min_level=2, max_level=4, min_tokens=0)
+        assert result[0]["line_start"] == 1
+        assert result[0]["line_end"] == 4
+        assert result[1]["line_start"] == 5
+        assert result[1]["line_end"] == 6
+
+    def test_anchor_generation(self):
+        text = "## Getting Started Guide\nContent.\n\n## API (v2) Reference!\nContent.\n"
+        result = split_by_headings(text, min_level=2, max_level=4, min_tokens=0)
+        assert result[0]["anchor"] == "getting-started-guide"
+        assert result[1]["anchor"] == "api-v2-reference"
+
+    def test_skips_code_block_headings(self):
+        text = (
+            "## Real Heading\nContent.\n\n"
+            "```markdown\n## Fake Heading Inside Code\n```\n\n"
+            "## Another Real Heading\nContent.\n"
+        )
+        result = split_by_headings(text, min_level=2, max_level=4, min_tokens=0)
+        assert len(result) == 2
+        titles = [r["title"] for r in result]
+        assert "Fake Heading Inside Code" not in titles
+
+    def test_respects_level_range(self):
+        text = "# H1\nContent.\n## H2\nContent.\n### H3\nContent.\n#### H4\nContent.\n##### H5\nContent.\n"
+        result = split_by_headings(text, min_level=2, max_level=3, min_tokens=0)
+        levels = [r["level"] for r in result]
+        assert all(2 <= l <= 3 for l in levels)
+
+    def test_merges_small_sections(self):
+        text = "## Big Section\n" + "Word " * 200 + "\n\n## Tiny\nOne line.\n\n## Another Big\n" + "Word " * 200 + "\n"
+        result = split_by_headings(text, min_level=2, max_level=4, min_tokens=100)
+        titles = [r["title"] for r in result]
+        assert "Tiny" not in titles
+
+    def test_no_headings_returns_empty(self):
+        text = "Just a plain text file.\nWith no headings at all.\n"
+        result = split_by_headings(text, min_level=2, max_level=4, min_tokens=0)
+        assert result == []
+
+    def test_text_preview_included(self):
+        text = "## Section\nFirst line of content.\nSecond line.\n"
+        result = split_by_headings(text, min_level=2, max_level=4, min_tokens=0)
+        assert "text_preview" in result[0]
+        assert "First line" in result[0]["text_preview"]

--- a/lib/corpus/scripts/tests/test_thin_sections.py
+++ b/lib/corpus/scripts/tests/test_thin_sections.py
@@ -1,6 +1,9 @@
 """Tests for thin_sections.py — bottom-up section merging."""
 import copy
+import json
+import subprocess
 import sys
+import yaml
 from pathlib import Path
 
 import pytest
@@ -98,3 +101,63 @@ class TestThinSections:
         result = thin_sections(index, min_tokens=100, dry_run=True)
         assert index == original
         assert result["sections_before"] >= 1
+
+
+class TestThinSectionsCLI:
+    """CLI integration tests."""
+
+    def test_cli_dry_run(self, tmp_path):
+        index = _make_index([
+            {"id": "src:a.md", "title": "A", "summary": "A docs", "tier": "file", "keywords": []},
+            {"id": "src:a.md#tiny", "title": "Tiny", "summary": "Short",
+             "tier": "section", "parent": "src:a.md", "heading_level": 2,
+             "line_range": [1, 3], "keywords": []},
+        ])
+        index_path = tmp_path / "index.yaml"
+        with open(index_path, "w") as f:
+            yaml.dump(index, f)
+        result = subprocess.run(
+            [sys.executable, str(Path(__file__).parent.parent / "thin_sections.py"),
+             "--index", str(index_path), "--min-tokens", "100", "--dry-run"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert "sections_before" in data
+
+    def test_cli_missing_index(self):
+        result = subprocess.run(
+            [sys.executable, str(Path(__file__).parent.parent / "thin_sections.py"),
+             "--index", "/nonexistent/index.yaml"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 1
+
+
+class TestThinSectionsEdgeCases:
+    def test_no_sections_in_index(self):
+        index = _make_index([
+            {"id": "src:a.md", "title": "A", "summary": "A docs", "tier": "file"},
+        ])
+        result = thin_sections(index, min_tokens=100)
+        assert len(result["entries"]) == 1
+
+    def test_chain_merge(self):
+        """When A is small and merges into B, and B was also small, the merge should still work."""
+        index = _make_index([
+            {"id": "src:a.md", "title": "A", "summary": "A docs " * 80, "tier": "file", "keywords": []},
+            {"id": "src:a.md#s1", "title": "S1", "summary": "Big " * 80,
+             "tier": "section", "parent": "src:a.md", "heading_level": 2,
+             "line_range": [1, 50], "keywords": ["s1"]},
+            {"id": "src:a.md#s2", "title": "S2", "summary": "Tiny",
+             "tier": "section", "parent": "src:a.md", "heading_level": 2,
+             "line_range": [51, 53], "keywords": ["s2"]},
+            {"id": "src:a.md#s3", "title": "S3", "summary": "Also tiny",
+             "tier": "section", "parent": "src:a.md", "heading_level": 2,
+             "line_range": [54, 56], "keywords": ["s3"]},
+        ])
+        result = thin_sections(index, min_tokens=100)
+        section_ids = [e["id"] for e in result["entries"] if e.get("tier") == "section"]
+        # s2 and s3 should both be merged (into s1 or cascaded)
+        assert "src:a.md#s2" not in section_ids
+        assert "src:a.md#s3" not in section_ids

--- a/lib/corpus/scripts/tests/test_thin_sections.py
+++ b/lib/corpus/scripts/tests/test_thin_sections.py
@@ -1,0 +1,100 @@
+"""Tests for thin_sections.py — bottom-up section merging."""
+import copy
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from thin_sections import thin_sections
+
+
+def _make_index(entries):
+    return {"meta": {"entry_count": len(entries)}, "entries": entries}
+
+
+class TestThinSections:
+    def test_merges_small_into_sibling(self):
+        index = _make_index([
+            {"id": "src:api.md", "title": "API", "summary": "API docs", "tier": "file"},
+            {"id": "src:api.md#methods", "title": "Methods", "summary": "Method docs " * 30,
+             "tier": "section", "parent": "src:api.md", "heading_level": 2,
+             "line_range": [10, 50], "keywords": ["methods"]},
+            {"id": "src:api.md#params", "title": "Parameters", "summary": "Short",
+             "tier": "section", "parent": "src:api.md", "heading_level": 2,
+             "line_range": [51, 55], "keywords": ["params"]},
+        ])
+        result = thin_sections(index, min_tokens=100)
+        section_ids = [e["id"] for e in result["entries"] if e.get("tier") == "section"]
+        assert "src:api.md#params" not in section_ids
+        methods = [e for e in result["entries"] if e["id"] == "src:api.md#methods"][0]
+        assert "params" in methods["keywords"]
+
+    def test_merges_into_parent_when_no_sibling(self):
+        index = _make_index([
+            {"id": "src:api.md", "title": "API", "summary": "API docs",
+             "tier": "file", "keywords": ["api"]},
+            {"id": "src:api.md#tiny", "title": "Tiny", "summary": "Short",
+             "tier": "section", "parent": "src:api.md", "heading_level": 2,
+             "line_range": [10, 12], "keywords": ["tiny"]},
+        ])
+        result = thin_sections(index, min_tokens=100)
+        section_ids = [e["id"] for e in result["entries"] if e.get("tier") == "section"]
+        assert "src:api.md#tiny" not in section_ids
+        parent = [e for e in result["entries"] if e["id"] == "src:api.md"][0]
+        assert "tiny" in parent["keywords"]
+
+    def test_never_merges_across_sources(self):
+        index = _make_index([
+            {"id": "src1:a.md", "title": "A", "summary": "A docs", "tier": "file"},
+            {"id": "src1:a.md#small", "title": "Small A", "summary": "Short",
+             "tier": "section", "parent": "src1:a.md", "heading_level": 2,
+             "line_range": [1, 3], "keywords": []},
+            {"id": "src2:b.md", "title": "B", "summary": "B docs " * 30, "tier": "file"},
+            {"id": "src2:b.md#big", "title": "Big B", "summary": "Big section " * 30,
+             "tier": "section", "parent": "src2:b.md", "heading_level": 2,
+             "line_range": [1, 50], "keywords": []},
+        ])
+        result = thin_sections(index, min_tokens=100)
+        section_ids = [e["id"] for e in result["entries"] if e.get("tier") == "section"]
+        assert "src1:a.md#small" not in section_ids
+
+    def test_never_merges_section_with_children(self):
+        index = _make_index([
+            {"id": "src:api.md", "title": "API", "summary": "API docs", "tier": "file"},
+            {"id": "src:api.md#parent", "title": "Parent", "summary": "Short",
+             "tier": "section", "parent": "src:api.md", "heading_level": 2,
+             "line_range": [10, 50], "keywords": []},
+            {"id": "src:api.md#child", "title": "Child", "summary": "Child section " * 30,
+             "tier": "section", "parent": "src:api.md#parent", "heading_level": 3,
+             "line_range": [20, 50], "keywords": []},
+        ])
+        result = thin_sections(index, min_tokens=100)
+        section_ids = [e["id"] for e in result["entries"] if e.get("tier") == "section"]
+        assert "src:api.md#parent" in section_ids
+
+    def test_updates_entry_count(self):
+        index = _make_index([
+            {"id": "src:api.md", "title": "API", "summary": "API docs", "tier": "file"},
+            {"id": "src:api.md#big", "title": "Big", "summary": "Big section " * 30,
+             "tier": "section", "parent": "src:api.md", "heading_level": 2,
+             "line_range": [10, 50], "keywords": []},
+            {"id": "src:api.md#tiny", "title": "Tiny", "summary": "Short",
+             "tier": "section", "parent": "src:api.md", "heading_level": 2,
+             "line_range": [51, 53], "keywords": []},
+        ])
+        result = thin_sections(index, min_tokens=100)
+        assert result["meta"]["entry_count"] == len(result["entries"])
+
+    def test_dry_run_returns_plan(self):
+        index = _make_index([
+            {"id": "src:api.md", "title": "API", "summary": "API docs", "tier": "file"},
+            {"id": "src:api.md#tiny", "title": "Tiny", "summary": "Short",
+             "tier": "section", "parent": "src:api.md", "heading_level": 2,
+             "line_range": [1, 3], "keywords": []},
+        ])
+        original = copy.deepcopy(index)
+        result = thin_sections(index, min_tokens=100, dry_run=True)
+        assert index == original
+        assert result["sections_before"] >= 1

--- a/lib/corpus/scripts/tests/test_thin_sections.py
+++ b/lib/corpus/scripts/tests/test_thin_sections.py
@@ -18,7 +18,7 @@ class TestThinSections:
     def test_merges_small_into_sibling(self):
         index = _make_index([
             {"id": "src:api.md", "title": "API", "summary": "API docs", "tier": "file"},
-            {"id": "src:api.md#methods", "title": "Methods", "summary": "Method docs " * 30,
+            {"id": "src:api.md#methods", "title": "Methods", "summary": "Method documentation content here " * 80,
              "tier": "section", "parent": "src:api.md", "heading_level": 2,
              "line_range": [10, 50], "keywords": ["methods"]},
             {"id": "src:api.md#params", "title": "Parameters", "summary": "Short",

--- a/lib/corpus/scripts/tests/test_token_utils.py
+++ b/lib/corpus/scripts/tests/test_token_utils.py
@@ -1,0 +1,35 @@
+"""Tests for token_utils.py — shared token counting."""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from token_utils import estimate_tokens
+
+
+class TestEstimateTokens:
+    """Token estimation with graceful fallback."""
+
+    def test_empty_string_returns_zero(self):
+        assert estimate_tokens("") == 0
+
+    def test_single_word(self):
+        result = estimate_tokens("hello")
+        assert result >= 1
+
+    def test_approximation_scales_with_length(self):
+        short = estimate_tokens("one two three")
+        long = estimate_tokens("one two three four five six seven eight nine ten")
+        assert long > short
+
+    def test_none_returns_zero(self):
+        assert estimate_tokens(None) == 0
+
+    def test_whitespace_only_returns_zero(self):
+        assert estimate_tokens("   \n\t  ") == 0
+
+    def test_returns_integer(self):
+        result = estimate_tokens("some words here for testing purposes")
+        assert isinstance(result, int)

--- a/lib/corpus/scripts/tests/test_verify_entries.py
+++ b/lib/corpus/scripts/tests/test_verify_entries.py
@@ -1,0 +1,77 @@
+"""Tests for verify_entries.py — entry content verification data prep."""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from verify_entries import extract_previews
+
+
+@pytest.fixture
+def sample_index(tmp_path):
+    index_yaml = tmp_path / "index.yaml"
+    index_yaml.write_text(
+        "meta:\n"
+        "  entry_count: 3\n"
+        "entries:\n"
+        "  - id: 'src:docs/intro.md'\n"
+        "    title: Introduction\n"
+        "    summary: Overview of the project\n"
+        "    source: docs/intro.md\n"
+        "  - id: 'src:docs/guide.md'\n"
+        "    title: Guide\n"
+        "    summary: How to use the tool\n"
+        "    source: docs/guide.md\n"
+        "  - id: 'src:docs/missing.md'\n"
+        "    title: Missing\n"
+        "    summary: This file does not exist\n"
+        "    source: docs/missing.md\n"
+    )
+    source_root = tmp_path / "source"
+    docs = source_root / "docs"
+    docs.mkdir(parents=True)
+    (docs / "intro.md").write_text("# Introduction\n\nThis is the overview of the project.\n" * 10)
+    (docs / "guide.md").write_text("# Guide\n\nStep by step instructions.\n" * 5)
+    return index_yaml, source_root
+
+
+class TestExtractPreviews:
+    def test_extracts_existing_files(self, sample_index):
+        index_yaml, source_root = sample_index
+        result = extract_previews(str(index_yaml), str(source_root), token_limit=500)
+        existing = [r for r in result if r["content_preview"] is not None]
+        assert len(existing) == 2
+        assert existing[0]["entry_id"] == "src:docs/intro.md"
+        assert "Introduction" in existing[0]["content_preview"]
+
+    def test_handles_missing_files(self, sample_index):
+        index_yaml, source_root = sample_index
+        result = extract_previews(str(index_yaml), str(source_root), token_limit=500)
+        missing = [r for r in result if r["content_preview"] is None]
+        assert len(missing) == 1
+        assert missing[0]["entry_id"] == "src:docs/missing.md"
+
+    def test_respects_token_limit(self, sample_index):
+        index_yaml, source_root = sample_index
+        result = extract_previews(str(index_yaml), str(source_root), token_limit=10)
+        for r in result:
+            if r["content_preview"] is not None:
+                word_count = len(r["content_preview"].split())
+                assert word_count <= 30
+
+    def test_sample_limits_count(self, sample_index):
+        index_yaml, source_root = sample_index
+        result = extract_previews(str(index_yaml), str(source_root), token_limit=500, sample=1)
+        assert len(result) == 1
+
+    def test_filter_by_entry_ids(self, sample_index):
+        index_yaml, source_root = sample_index
+        result = extract_previews(
+            str(index_yaml), str(source_root), token_limit=500,
+            entry_ids=["src:docs/guide.md"]
+        )
+        assert len(result) == 1
+        assert result[0]["entry_id"] == "src:docs/guide.md"

--- a/lib/corpus/scripts/tests/test_verify_entries.py
+++ b/lib/corpus/scripts/tests/test_verify_entries.py
@@ -1,5 +1,6 @@
 """Tests for verify_entries.py — entry content verification data prep."""
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -75,3 +76,34 @@ class TestExtractPreviews:
         )
         assert len(result) == 1
         assert result[0]["entry_id"] == "src:docs/guide.md"
+
+
+class TestVerifyEntriesCLI:
+    """CLI integration tests."""
+
+    def test_cli_json_output(self, sample_index):
+        index_yaml, source_root = sample_index
+        result = subprocess.run(
+            [sys.executable, str(Path(__file__).parent.parent / "verify_entries.py"),
+             "--index", str(index_yaml), "--source-root", str(source_root)],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert len(data) == 3
+
+    def test_cli_missing_index(self):
+        result = subprocess.run(
+            [sys.executable, str(Path(__file__).parent.parent / "verify_entries.py"),
+             "--index", "/nonexistent/index.yaml", "--source-root", "/tmp"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode != 0
+
+
+class TestVerifyEntriesEdgeCases:
+    def test_empty_index(self, tmp_path):
+        index_yaml = tmp_path / "index.yaml"
+        index_yaml.write_text("meta:\n  entry_count: 0\nentries: []\n")
+        result = extract_previews(str(index_yaml), str(tmp_path), token_limit=500)
+        assert result == []

--- a/lib/corpus/scripts/tests/test_yaml_fallback.py
+++ b/lib/corpus/scripts/tests/test_yaml_fallback.py
@@ -1,0 +1,108 @@
+"""Tests for PyYAML regex fallback parsers.
+
+Tests the regex-based parsers directly to ensure they work when PyYAML
+is unavailable. These parse the same formats as the YAML parsers but
+using regex.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from detect_nav import _parse_mkdocs_nav_regex
+from verify_entries import _load_index_regex
+
+
+class TestMkdocsNavRegexFallback:
+    """Test _parse_mkdocs_nav_regex directly."""
+
+    def test_flat_nav(self, tmp_path):
+        mkdocs = tmp_path / "mkdocs.yml"
+        mkdocs.write_text(
+            "site_name: Test\n"
+            "nav:\n"
+            "  - Home: index.md\n"
+            "  - Guide: guide.md\n"
+            "  - API: api/reference.md\n"
+        )
+        result = _parse_mkdocs_nav_regex(mkdocs, tmp_path)
+        assert len(result) == 3
+        assert result[0]["title"] == "Home"
+        assert result[0]["path"] == "index.md"
+        assert result[1]["title"] == "Guide"
+        assert result[2]["path"] == "api/reference.md"
+
+    def test_stops_at_next_top_level_key(self, tmp_path):
+        mkdocs = tmp_path / "mkdocs.yml"
+        mkdocs.write_text(
+            "nav:\n"
+            "  - Home: index.md\n"
+            "  - About: about.md\n"
+            "theme:\n"
+            "  name: material\n"
+        )
+        result = _parse_mkdocs_nav_regex(mkdocs, tmp_path)
+        assert len(result) == 2  # should not parse theme section
+
+    def test_empty_nav(self, tmp_path):
+        mkdocs = tmp_path / "mkdocs.yml"
+        mkdocs.write_text("nav:\ntheme:\n  name: material\n")
+        result = _parse_mkdocs_nav_regex(mkdocs, tmp_path)
+        assert result == []
+
+    def test_no_nav_key(self, tmp_path):
+        mkdocs = tmp_path / "mkdocs.yml"
+        mkdocs.write_text("site_name: Test\ntheme:\n  name: material\n")
+        result = _parse_mkdocs_nav_regex(mkdocs, tmp_path)
+        assert result == []
+
+
+class TestIndexRegexFallback:
+    """Test _load_index_regex directly."""
+
+    def test_parses_entries(self, tmp_path):
+        index = tmp_path / "index.yaml"
+        index.write_text(
+            "meta:\n"
+            "  entry_count: 2\n"
+            "entries:\n"
+            "  - id: 'src:docs/intro.md'\n"
+            "    title: Introduction\n"
+            "    summary: Overview of the project\n"
+            "    source: docs/intro.md\n"
+            "  - id: 'src:docs/guide.md'\n"
+            "    title: Guide\n"
+            "    summary: How to use the tool\n"
+            "    source: docs/guide.md\n"
+        )
+        result = _load_index_regex(str(index))
+        assert len(result) == 2
+        assert result[0]["id"] == "src:docs/intro.md"
+        assert result[0]["title"] == "Introduction"
+        assert result[0]["source"] == "docs/intro.md"
+        assert result[1]["id"] == "src:docs/guide.md"
+
+    def test_strips_quotes(self, tmp_path):
+        index = tmp_path / "index.yaml"
+        index.write_text(
+            "entries:\n"
+            "  - id: \"src:file.md\"\n"
+            "    title: 'Quoted Title'\n"
+        )
+        result = _load_index_regex(str(index))
+        assert result[0]["id"] == "src:file.md"
+        assert result[0]["title"] == "Quoted Title"
+
+    def test_empty_file(self, tmp_path):
+        index = tmp_path / "index.yaml"
+        index.write_text("")
+        result = _load_index_regex(str(index))
+        assert result == []
+
+    def test_no_entries(self, tmp_path):
+        index = tmp_path / "index.yaml"
+        index.write_text("meta:\n  entry_count: 0\n")
+        result = _load_index_regex(str(index))
+        assert result == []

--- a/lib/corpus/scripts/thin_sections.py
+++ b/lib/corpus/scripts/thin_sections.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Bottom-up merge of small section entries in index.yaml.
+
+Usage:
+  python3 thin_sections.py --index <path> [--min-tokens 300] [--dry-run]
+
+Merges section entries below min-tokens into nearest sibling or parent.
+Modifies index.yaml in-place unless --dry-run.
+
+Output: JSON summary to stdout with sections_before, sections_after, merged[].
+
+Exit codes:
+  0 - success
+  1 - invalid arguments or missing index
+  2 - python error
+"""
+import argparse
+import copy
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from token_utils import estimate_tokens
+
+
+def _has_children(entry_id: str, entries: list[dict]) -> bool:
+    return any(e.get("parent") == entry_id for e in entries)
+
+
+def _source_prefix(entry_id: str) -> str:
+    if ":" in entry_id:
+        return entry_id.split(":")[0]
+    return ""
+
+
+def thin_sections(
+    index: dict,
+    min_tokens: int = 300,
+    dry_run: bool = False,
+) -> dict:
+    if dry_run:
+        work = copy.deepcopy(index)
+    else:
+        work = index
+
+    entries = work.get("entries", [])
+    sections = [e for e in entries if e.get("tier") == "section"]
+    sections_before = len(sections)
+    merged_log = []
+
+    sections_by_depth = sorted(sections, key=lambda e: e.get("heading_level", 0), reverse=True)
+    ids_to_remove = set()
+
+    for section in sections_by_depth:
+        sid = section["id"]
+        if sid in ids_to_remove:
+            continue
+        if _has_children(sid, entries):
+            continue
+
+        text = (section.get("summary", "") + " " + " ".join(section.get("keywords", []))).strip()
+        tokens = estimate_tokens(text)
+        if tokens >= min_tokens:
+            continue
+
+        parent_id = section.get("parent")
+        source_pfx = _source_prefix(sid)
+
+        siblings = [
+            e for e in entries
+            if e.get("parent") == parent_id
+            and e.get("tier") == "section"
+            and _source_prefix(e["id"]) == source_pfx
+            and e["id"] != sid
+            and e["id"] not in ids_to_remove
+        ]
+
+        prev_sibling = None
+        section_start = (section.get("line_range") or [0])[0]
+        for sib in siblings:
+            sib_start = (sib.get("line_range") or [0])[0]
+            if sib_start < section_start:
+                if prev_sibling is None or sib_start > (prev_sibling.get("line_range") or [0])[0]:
+                    prev_sibling = sib
+
+        if prev_sibling:
+            target = prev_sibling
+            target_id = target["id"]
+        elif parent_id:
+            target = next((e for e in entries if e["id"] == parent_id), None)
+            if target is None:
+                continue
+            target_id = target["id"]
+        else:
+            continue
+
+        if _source_prefix(target_id) != source_pfx:
+            continue
+
+        target_kw = target.get("keywords", [])
+        section_kw = section.get("keywords", [])
+        target["keywords"] = list(dict.fromkeys(target_kw + section_kw))
+
+        if target.get("line_range") and section.get("line_range"):
+            target["line_range"][1] = max(target["line_range"][1], section["line_range"][1])
+
+        if section.get("summary"):
+            target["summary"] = (target.get("summary", "") + " " + section["summary"]).strip()
+
+        ids_to_remove.add(sid)
+        merged_log.append({
+            "removed_id": sid,
+            "merged_into": target_id,
+            "reason": f"{tokens} tokens (below {min_tokens} threshold)",
+        })
+
+    work["entries"] = [e for e in entries if e["id"] not in ids_to_remove]
+    work["meta"]["entry_count"] = len(work["entries"])
+
+    sections_after = len([e for e in work["entries"] if e.get("tier") == "section"])
+
+    if dry_run:
+        return {
+            "sections_before": sections_before,
+            "sections_after": sections_after,
+            "merged": merged_log,
+        }
+    return work
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Thin section entries in index.yaml")
+    parser.add_argument("--index", required=True, help="Path to index.yaml")
+    parser.add_argument("--min-tokens", type=int, default=300, help="Min tokens per section (default: 300)")
+    parser.add_argument("--dry-run", action="store_true", help="Show plan without modifying")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    index_path = Path(args.index)
+    if not index_path.exists():
+        print(f"error: index not found: {args.index}", file=sys.stderr)
+        sys.exit(1)
+    try:
+        import yaml
+    except ImportError:
+        print("error: PyYAML required for thin_sections.py", file=sys.stderr)
+        sys.exit(1)
+
+    with open(index_path) as f:
+        index = yaml.safe_load(f)
+
+    if args.dry_run:
+        result = thin_sections(index, args.min_tokens, dry_run=True)
+        print(json.dumps(result, indent=2))
+    else:
+        result = thin_sections(index, args.min_tokens, dry_run=False)
+        with open(index_path, "w") as f:
+            yaml.dump(result, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+        summary = {
+            "sections_before": len([e for e in index.get("entries", []) if e.get("tier") == "section"]),
+            "sections_after": len([e for e in result["entries"] if e.get("tier") == "section"]),
+            "merged": [],
+        }
+        print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception as e:
+        print(f"error: {e}", file=sys.stderr)
+        sys.exit(2)

--- a/lib/corpus/scripts/token_utils.py
+++ b/lib/corpus/scripts/token_utils.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Shared token counting with graceful fallback.
+
+Tries fastembed's tokenizer first (accurate), falls back to
+word-count approximation (len(text.split()) * 1.3).
+
+Usage as module:
+  from token_utils import estimate_tokens
+  count = estimate_tokens("some text here")
+"""
+
+TOKENS_PER_WORD = 1.3
+
+_tokenizer = None
+_tokenizer_checked = False
+
+
+def _get_tokenizer():
+    """Try to load fastembed tokenizer once, cache result."""
+    global _tokenizer, _tokenizer_checked
+    if _tokenizer_checked:
+        return _tokenizer
+    _tokenizer_checked = True
+    try:
+        from fastembed import TextEmbedding
+
+        model = TextEmbedding("BAAI/bge-small-en-v1.5")
+        _tokenizer = model.model.tokenizer
+    except Exception:
+        _tokenizer = None
+    return _tokenizer
+
+
+def estimate_tokens(text: str | None) -> int:
+    """Estimate token count for text.
+
+    Returns 0 for None, empty, or whitespace-only strings.
+    Uses fastembed tokenizer if available, else word-count * 1.3.
+    """
+    if not text or not text.strip():
+        return 0
+
+    tokenizer = _get_tokenizer()
+    if tokenizer is not None:
+        try:
+            return len(tokenizer.encode(text).ids)
+        except Exception:
+            pass
+
+    return int(len(text.split()) * TOKENS_PER_WORD)

--- a/lib/corpus/scripts/verify_entries.py
+++ b/lib/corpus/scripts/verify_entries.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Extract content previews for index entries (data prep for LLM verification).
+
+Usage:
+  python3 verify_entries.py --index <path> --source-root <path> [--token-limit 500] [--sample N] [--entries ID,ID,...]
+
+Output: JSON array to stdout. Each entry: {entry_id, title, summary, source_path, content_preview, token_count}.
+
+Exit codes:
+  0 - success
+  1 - invalid arguments or missing index
+  2 - python error
+"""
+import argparse
+import json
+import random
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from token_utils import estimate_tokens
+
+
+def _load_index(index_path: str) -> list[dict]:
+    try:
+        import yaml
+    except ImportError:
+        return _load_index_regex(index_path)
+    with open(index_path) as f:
+        data = yaml.safe_load(f)
+    return data.get("entries", []) if isinstance(data, dict) else []
+
+
+def _load_index_regex(index_path: str) -> list[dict]:
+    text = Path(index_path).read_text()
+    entries = []
+    current = None
+    for line in text.splitlines():
+        if line.strip().startswith("- id:"):
+            if current:
+                entries.append(current)
+            current = {"id": line.split(":", 1)[1].strip().strip("'\"")}
+        elif current and ":" in line and line.startswith("    "):
+            key, _, val = line.strip().partition(":")
+            current[key.strip()] = val.strip().strip("'\"")
+    if current:
+        entries.append(current)
+    return entries
+
+
+def _truncate_to_tokens(text: str, token_limit: int) -> str:
+    words = text.split()
+    word_limit = int(token_limit / 1.3) + 1
+    if len(words) <= word_limit:
+        return text
+    return " ".join(words[:word_limit])
+
+
+def extract_previews(
+    index_path: str,
+    source_root: str,
+    token_limit: int = 500,
+    sample: int | None = None,
+    entry_ids: list[str] | None = None,
+) -> list[dict]:
+    entries = _load_index(index_path)
+    source = Path(source_root)
+
+    if entry_ids:
+        id_set = set(entry_ids)
+        entries = [e for e in entries if e.get("id") in id_set]
+
+    if sample is not None and sample < len(entries):
+        entries = random.sample(entries, sample)
+
+    result = []
+    for entry in entries:
+        entry_id = entry.get("id", "")
+        title = entry.get("title", "")
+        summary = entry.get("summary", "")
+        source_path = entry.get("source", "")
+        file_path = source / source_path
+
+        if file_path.exists():
+            content = file_path.read_text(errors="replace")
+            preview = _truncate_to_tokens(content, token_limit)
+            token_count = estimate_tokens(preview)
+        else:
+            preview = None
+            token_count = 0
+
+        result.append({
+            "entry_id": entry_id, "title": title, "summary": summary,
+            "source_path": source_path, "content_preview": preview, "token_count": token_count,
+        })
+    return result
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Extract content previews for entry verification")
+    parser.add_argument("--index", required=True, help="Path to index.yaml")
+    parser.add_argument("--source-root", required=True, help="Path to source root directory")
+    parser.add_argument("--token-limit", type=int, default=500, help="Max tokens per preview (default: 500)")
+    parser.add_argument("--sample", type=int, default=None, help="Random sample N entries (default: all)")
+    parser.add_argument("--entries", default=None, help="Comma-separated entry IDs to verify")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    entry_ids = args.entries.split(",") if args.entries else None
+    result = extract_previews(args.index, args.source_root, token_limit=args.token_limit, sample=args.sample, entry_ids=entry_ids)
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception as e:
+        print(f"error: {e}", file=sys.stderr)
+        sys.exit(2)

--- a/skills/hiivmind-corpus-build/SKILL.md
+++ b/skills/hiivmind-corpus-build/SKILL.md
@@ -179,6 +179,37 @@ Scan Results
 Total: {total_files} files across {source_count} sources
 ```
 
+### Tree Thinning (post Phase 2c)
+
+```pseudocode
+GUARD_TREE_THINNING():
+  section_count = count(entry for entry in computed.scan_results if entry.tier == "section")
+  IF section_count == 0:
+    SKIP "No section entries to thin."
+    PROCEED to next phase
+
+  has_token_config = ANY(source.sections.min_section_tokens IS NOT null for source in config.sources)
+  IF NOT has_token_config:
+    SKIP "Tree thinning not configured (no min_section_tokens in any source)."
+    PROCEED to next phase
+
+  result = Bash("python3 ${PLUGIN_ROOT}/lib/corpus/scripts/thin_sections.py --index index.yaml --min-tokens {min_section_tokens} --dry-run")
+
+  IF result.exit_code != 0:
+    DISPLAY "Tree thinning failed: {stderr}. Proceeding with unthinned sections."
+    PROCEED to next phase
+
+  IF result.sections_before == result.sections_after:
+    DISPLAY "Tree thinning: all sections above threshold. No merges needed."
+    PROCEED to next phase
+
+  DISPLAY "Tree thinning would merge {sections_before - sections_after} sections."
+  ASK user: "Apply these merges? [Y/n]"
+  IF user approves:
+    Bash("python3 ${PLUGIN_ROOT}/lib/corpus/scripts/thin_sections.py --index index.yaml --min-tokens {min_section_tokens}")
+    DISPLAY "Thinned: {sections_before} → {sections_after} sections."
+```
+
 ---
 
 ## Phase 3: Determine Segmentation Strategy
@@ -556,6 +587,43 @@ GUARD_PHASE_7():
 5. Display: "Generated chunk embeddings for {chunk_count} chunks across {source_count} sources"
 
 **Commit guidance:** `chunks-embeddings.lance/` MUST be committed alongside other corpus files. Do NOT add to `.gitignore`.
+
+---
+
+## Phase 7c: Verification
+
+```pseudocode
+GUARD_PHASE_7C_VERIFICATION():
+  IF computed.index IS null:
+    DISPLAY "Cannot verify: index has not been generated."
+    EXIT
+
+  verify_enabled = config.build.verify_on_build
+  IF verify_enabled IS null:
+    verify_enabled = (computed.index.meta.entry_count < 200)
+
+  IF verify_enabled == false:
+    SKIP "Verification skipped."
+    PROCEED to Phase 8
+
+  sample_size = config.build.verify_sample_size OR 20
+  result = Bash("python3 ${CLAUDE_PLUGIN_ROOT}/lib/corpus/scripts/verify_entries.py --index index.yaml --source-root .source/ --sample {sample_size}")
+
+  IF result.exit_code != 0:
+    DISPLAY "Verification script failed. Proceeding without verification."
+    PROCEED to Phase 8
+
+  # LLM verification of previews in batches of 10
+  inaccurate = LLM_VERIFY(result)
+
+  IF len(inaccurate) == 0:
+    DISPLAY "Verification passed: all entries accurate."
+  ELSE:
+    DISPLAY "Verification found {N} entries with summary drift."
+    ASK user: "Regenerate summaries for these entries? [Y/n]"
+    IF user approves:
+      regenerate and re-embed if needed
+```
 
 ---
 

--- a/skills/hiivmind-corpus-refresh/SKILL.md
+++ b/skills/hiivmind-corpus-refresh/SKILL.md
@@ -323,6 +323,31 @@ Index entries: {added} added, {modified} modified, {removed} removed
 
 ---
 
+## Post-Refresh Verification (optional)
+
+```pseudocode
+GUARD_REFRESH_VERIFICATION():
+  IF computed.changes_applied IS null OR len(computed.changes_applied) == 0:
+    SKIP "No changes applied. Skipping verification."
+
+  modified_ids = [c.entry_id for c in computed.changes_applied if c.action in ("modified", "added")]
+  IF len(modified_ids) == 0:
+    SKIP "Only deletions applied. Skipping verification."
+
+  result = Bash("python3 ${CLAUDE_PLUGIN_ROOT}/lib/corpus/scripts/verify_entries.py --index index.yaml --source-root .source/ --entries {modified_ids}")
+
+  IF result.exit_code != 0:
+    DISPLAY "Post-refresh verification failed. Proceeding."
+
+  inaccurate = LLM_VERIFY(result)
+
+  IF len(inaccurate) > 0:
+    DISPLAY "Post-refresh verification found {N} entries with summary drift."
+    ASK user: "Regenerate? [Y/n]"
+```
+
+---
+
 ## Error Handling
 
 | Error | Message | Recovery |


### PR DESCRIPTION
## Summary

Five algorithms adapted from [VectifyAI/PageIndex](https://github.com/VectifyAI/PageIndex) to improve corpus build quality:

- **Nav detection** (`detect_nav.py`) — Parse mkdocs.yml / _sidebar.md / SUMMARY.md into a hierarchy skeleton before scanning, with coverage-threshold decision logic
- **Entry verification** (`verify_entries.py`) — Extract content previews for LLM-based summary accuracy checking after build or refresh
- **Tree thinning** (`thin_sections.py`) — Bottom-up merge of trivially small section entries using token counts instead of line-count heuristics
- **Large-file splitting** (`detect_large_files.py` + `split_by_headings.py`) — Auto-generate sub-entries for large files with heading structure, falling back to existing GREP markers for unstructured files
- **Structure-aware chunking** (`headings` strategy in `chunk.py`) — Chunk at natural heading boundaries with paragraph fallback, each chunk carrying `heading_context` for richer embeddings

All algorithms implemented as deterministic Python scripts in `lib/corpus/scripts/` with 73 passing tests. Skill/agent prompts updated with GUARD blocks, skip conditions, and post-step summaries matching existing patterns.

## Changes

- **6 new scripts** with full test suites (+ 1 shared `token_utils.py`)
- **Modified** `chunk.py` (new `headings` strategy), `embed.py` (heading_context in chunk embeddings)
- **Updated** source-scanner agent, build skill, refresh skill with integration pseudocode
- **Updated** CLAUDE.md cross-cutting concerns table and dependency chain

## Test plan

- [x] Full test suite: 73 passed, 23 skipped (pre-existing optional dep skips), 0 failures
- [x] All scripts import cleanly (`--help` exits 0)
- [x] No changes to index.yaml schema, navigate skill, or embedding format
- [x] Existing chunking strategies unchanged (no regression)
- [ ] Manual: build a corpus with mkdocs.yml source, verify nav skeleton is used
- [ ] Manual: build a corpus with large files, verify auto-splitting

🤖 Generated with [Claude Code](https://claude.com/claude-code)