### PR TITLE
Prefer uv for embedding install hints, bump to v1.5.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   "repository": "https://github.com/hiivmind/hiivmind-corpus",
   "metadata": {
     "description": "Meta-plugin for creating documentation corpus skills - index and navigate any open source project docs",
-    "version": "1.5.0"
+    "version": "1.5.1"
   },
   "plugins": [
     {
       "name": "hiivmind-corpus",
       "source": "./",
       "description": "Create, build, and maintain documentation corpus skills for any project",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "keywords": [
         "documentation",
         "corpus",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hiivmind-corpus",
   "description": "Meta-plugin for creating documentation corpus skills - index and navigate any open source project docs",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "MIT",
   "author": {
     "name": "Nathaniel Ramm",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hiivmind-corpus",
   "description": "Meta-plugin for creating documentation corpus skills - index and navigate any open source project docs",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "skills": "./skills/",
   "commands": "./commands/",
   "agents": "./agents/",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Meta-plugin for creating documentation corpus skills - index and navigate any open source project docs",
-    "version": "1.5.0"
+    "version": "1.5.1"
   },
   "plugins": [
     {
       "name": "hiivmind-corpus",
       "source": "./",
       "description": "Create, build, and maintain documentation corpus skills for any project",
-      "version": "1.5.0"
+      "version": "1.5.1"
     }
   ]
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "hiivmind-corpus",
   "displayName": "hiivmind-corpus",
   "description": "Meta-plugin for creating documentation corpus skills - index and navigate any open source project docs",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": {
     "name": "Nathaniel Ramm",
     "email": "nathaniel.ramm@discretedatascience.com"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "hiivmind-corpus",
   "description": "Meta-plugin for creating documentation corpus skills - index and navigate any open source project docs",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "contextFileName": "GEMINI.md",
   "author": "Nathaniel Ramm",
   "homepage": "https://github.com/hiivmind/hiivmind-corpus#readme"

--- a/lib/corpus/patterns/embeddings.md
+++ b/lib/corpus/patterns/embeddings.md
@@ -12,7 +12,7 @@ and stores them in Lance format for hybrid vector + SQL search.
 - `pyarrow` — Columnar data (transitive dependency of lancedb)
 - Model: `BAAI/bge-small-en-v1.5` (~45MB, auto-downloaded on first use)
 
-Install: `pip install fastembed lancedb pyyaml` (~260MB total)
+Install: `uv pip install fastembed lancedb pyyaml` (~260MB total, or `pip install` if not using uv)
 
 ## Dependency Detection
 
@@ -29,7 +29,7 @@ python3 ${CLAUDE_PLUGIN_ROOT}/lib/corpus/scripts/detect.py
 | `not-installed` | 1 | fastembed or lancedb not available |
 
 **Install prompt** (when heuristic recommends embeddings):
-> "Enable semantic search? Requires: `pip install fastembed lancedb pyyaml` (~260MB)"
+> "Enable semantic search? Requires: `uv pip install fastembed lancedb pyyaml` (~260MB)"
 
 **Model download note** (when detect.py reports "no-model"):
 > "Downloading embedding model (~45MB, one-time)..."

--- a/lib/corpus/scripts/detect.py
+++ b/lib/corpus/scripts/detect.py
@@ -13,9 +13,20 @@ Exit codes:
   1 - dependencies not installed
   2 - python error
 """
+
 import sys
 
 MODEL_NAME = "BAAI/bge-small-en-v1.5"
+
+
+def _install_hint() -> str:
+    """Return the install command, preferring uv if available."""
+    import shutil
+
+    pkg = "fastembed lancedb pyyaml"
+    if shutil.which("uv"):
+        return f"uv pip install {pkg}"
+    return f"pip install {pkg}"
 
 
 def main():
@@ -23,12 +34,14 @@ def main():
         import fastembed  # noqa: F401
     except ImportError:
         print("not-installed")
+        print(f"Install with: {_install_hint()}", file=sys.stderr)
         sys.exit(1)
 
     try:
         import lancedb  # noqa: F401
     except ImportError:
         print("not-installed")
+        print(f"Install with: {_install_hint()}", file=sys.stderr)
         sys.exit(1)
 
     # Check if model is already downloaded.
@@ -39,9 +52,7 @@ def main():
         from pathlib import Path
 
         cache_path = Path.home() / ".cache" / "fastembed"
-        model_dirs = (
-            list(cache_path.glob("*bge-small*")) if cache_path.exists() else []
-        )
+        model_dirs = list(cache_path.glob("*bge-small*")) if cache_path.exists() else []
         if model_dirs:
             print("ready")
         else:

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hiivmind-corpus",
   "name": "hiivmind-corpus",
   "description": "Meta-plugin for creating documentation corpus skills - index and navigate any open source project docs",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "skills": [
     "skills/hiivmind-corpus-add-source",
     "skills/hiivmind-corpus-bridge",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hiivmind-corpus",
   "displayName": "hiivmind-corpus",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Meta-plugin for creating documentation corpus skills - index and navigate any open source project docs",
   "publisher": "hiivmind",
   "author": "Nathaniel Ramm",


### PR DESCRIPTION
## Summary
- Update embedding install instructions to prefer `uv pip` over plain `pip`
- Add `_install_hint()` helper to `detect.py` that auto-detects uv and suggests the appropriate install command on stderr
- Bump version 1.5.0 → 1.5.1 across all 8 plugin manifests (10 occurrences)

## Test plan
- [ ] Run `python3 lib/corpus/scripts/detect.py` without fastembed installed — verify stderr shows `uv pip install` (if uv available) or `pip install` fallback
- [ ] Confirm version is 1.5.1 in all manifests: `grep -r "1.5.1" --include="*.json" .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)