### PR TITLE
Fix headless refresh index rules, bump to v1.5.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   "repository": "https://github.com/hiivmind/hiivmind-corpus",
   "metadata": {
     "description": "Meta-plugin for creating documentation corpus skills - index and navigate any open source project docs",
-    "version": "1.5.1"
+    "version": "1.5.2"
   },
   "plugins": [
     {
       "name": "hiivmind-corpus",
       "source": "./",
       "description": "Create, build, and maintain documentation corpus skills for any project",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "keywords": [
         "documentation",
         "corpus",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hiivmind-corpus",
   "description": "Meta-plugin for creating documentation corpus skills - index and navigate any open source project docs",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "license": "MIT",
   "author": {
     "name": "Nathaniel Ramm",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hiivmind-corpus",
   "description": "Meta-plugin for creating documentation corpus skills - index and navigate any open source project docs",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "skills": "./skills/",
   "commands": "./commands/",
   "agents": "./agents/",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Meta-plugin for creating documentation corpus skills - index and navigate any open source project docs",
-    "version": "1.5.1"
+    "version": "1.5.2"
   },
   "plugins": [
     {
       "name": "hiivmind-corpus",
       "source": "./",
       "description": "Create, build, and maintain documentation corpus skills for any project",
-      "version": "1.5.1"
+      "version": "1.5.2"
     }
   ]
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "hiivmind-corpus",
   "displayName": "hiivmind-corpus",
   "description": "Meta-plugin for creating documentation corpus skills - index and navigate any open source project docs",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "author": {
     "name": "Nathaniel Ramm",
     "email": "nathaniel.ramm@discretedatascience.com"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "hiivmind-corpus",
   "description": "Meta-plugin for creating documentation corpus skills - index and navigate any open source project docs",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "contextFileName": "GEMINI.md",
   "author": "Nathaniel Ramm",
   "homepage": "https://github.com/hiivmind/hiivmind-corpus#readme"

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "hiivmind-corpus",
   "name": "hiivmind-corpus",
   "description": "Meta-plugin for creating documentation corpus skills - index and navigate any open source project docs",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "skills": [
     "skills/hiivmind-corpus-add-source",
     "skills/hiivmind-corpus-bridge",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hiivmind-corpus",
   "displayName": "hiivmind-corpus",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Meta-plugin for creating documentation corpus skills - index and navigate any open source project docs",
   "publisher": "hiivmind",
   "author": "Nathaniel Ramm",

--- a/skills/hiivmind-corpus-refresh-headless/SKILL.md
+++ b/skills/hiivmind-corpus-refresh-headless/SKILL.md
@@ -191,8 +191,10 @@ Per-change rules:
   Template variables (e.g. Liquid `{% data variables.X.Y %}`) must be resolved or stripped
   **before** truncating — truncating mid-tag leaves broken markup in the index.
 
-  Group added entries by subdirectory under an `## New in This Refresh` section when there
-  are more than ~15 additions in a section file.
+  Place each entry in the appropriate existing `##` section based on path structure
+  (e.g. `copilot/concepts/...` → `## Concepts`, `copilot/how-tos/...` → `## How-Tos`).
+  Never stage entries under a temporary heading like "New in This Refresh" — the index
+  is a durable source of truth, not a changelog.
 
 ### Update config.yaml (both formats)
 

--- a/skills/hiivmind-corpus-refresh-headless/SKILL.md
+++ b/skills/hiivmind-corpus-refresh-headless/SKILL.md
@@ -172,6 +172,28 @@ or the graph skill respectively.
 Apply changes directly to `index.md`. If tiered (glob `index-*.md`), map changes to
 affected sub-indexes and update each. See `patterns/sources/shared.md`.
 
+Per-change rules:
+
+- **D (deleted):** Remove the entry line from the relevant section file.
+- **M (modified):** Path is unchanged — the entry reference remains valid. No section edit needed.
+- **A (added):** Read the file from `.source/{id}/` and extract a real title and intro **before** writing the entry. Never write a directory summary or placeholder stub — v1 has no re-scan phase, so entries need real content from the start.
+
+  ```pseudocode
+  FOR EACH added_path IN source.files_changed WHERE status == "A":
+    content = git_show(".source/{source.id}", "HEAD:{docs_root}/{relative_path}")
+    title   = frontmatter.title OR frontmatter.shortTitle OR first_h1(content) OR filename_humanized
+    intro   = frontmatter.intro (clean template vars, truncate to ~120 chars)
+    entry   = "- **{title}** `{source.id}:{relative_path}`"
+    IF intro: entry += " — {intro}"
+    append entry to relevant section in index file
+  ```
+
+  Template variables (e.g. Liquid `{% data variables.X.Y %}`) must be resolved or stripped
+  **before** truncating — truncating mid-tag leaves broken markup in the index.
+
+  Group added entries by subdirectory under an `## New in This Refresh` section when there
+  are more than ~15 additions in a section file.
+
 ### Update config.yaml (both formats)
 
 For each updated source: advance `last_indexed_at`, and `last_commit_sha` (git/self/generated-docs)

--- a/skills/hiivmind-corpus-refresh/SKILL.md
+++ b/skills/hiivmind-corpus-refresh/SKILL.md
@@ -261,12 +261,34 @@ requires running the graph skill's add-concept with updated entry selection.
 
 ### v1 format (index.md only)
 
+Per-change rules (apply to both single and tiered):
+
+- **D (deleted):** Remove the entry line from the relevant section file.
+- **M (modified):** Path is unchanged — the entry reference remains valid. No section edit needed.
+- **A (added):** Read the file from `.source/{id}/` and extract a real title and intro **before** writing the entry. Never write a directory summary or placeholder stub — v1 has no re-scan phase, so entries need real content from the start.
+
+  ```pseudocode
+  FOR EACH added_path IN source.files_changed WHERE status == "A":
+    content = git_show(".source/{source.id}", "HEAD:{docs_root}/{relative_path}")
+    title   = frontmatter.title OR frontmatter.shortTitle OR first_h1(content) OR filename_humanized
+    intro   = frontmatter.intro (clean template vars, truncate to ~120 chars)
+    entry   = "- **{title}** `{source.id}:{relative_path}`"
+    IF intro: entry += " — {intro}"
+    append entry to relevant section in index file
+  ```
+
+  Template variables (e.g. Liquid `{% data variables.X.Y %}`) must be resolved or stripped
+  **before** truncating — truncating mid-tag leaves broken markup in the index.
+
+  Group added entries by subdirectory under an `## New in This Refresh` section when there
+  are more than ~15 additions in a section file.
+
 #### Single index
 
 If `computed.index_structure.is_tiered` is false:
 
 1. Read `index.md`
-2. Apply changes: update existing entries, add new entries, mark removed entries
+2. Apply changes per rules above
 3. Show preview of changes to user
 4. If `auto_approve` or user confirms → save index.md
 
@@ -278,7 +300,7 @@ If `computed.index_structure.is_tiered` is true:
 2. Present affected sections to user
 3. For each affected sub-index:
    - Read `index-{section}.md`
-   - Apply relevant changes
+   - Apply relevant changes per rules above
    - Save
 4. Update main `index.md` summary section
 5. If `auto_approve` or user confirms → save all files

--- a/skills/hiivmind-corpus-refresh/SKILL.md
+++ b/skills/hiivmind-corpus-refresh/SKILL.md
@@ -280,8 +280,10 @@ Per-change rules (apply to both single and tiered):
   Template variables (e.g. Liquid `{% data variables.X.Y %}`) must be resolved or stripped
   **before** truncating — truncating mid-tag leaves broken markup in the index.
 
-  Group added entries by subdirectory under an `## New in This Refresh` section when there
-  are more than ~15 additions in a section file.
+  Place each entry in the appropriate existing `##` section based on path structure
+  (e.g. `copilot/concepts/...` → `## Concepts`, `copilot/how-tos/...` → `## How-Tos`).
+  Never stage entries under a temporary heading like "New in This Refresh" — the index
+  is a durable source of truth, not a changelog.
 
 #### Single index
 


### PR DESCRIPTION
## Summary
- Specify v1 index rules for added files in refresh skills
- Entries go in existing sections, not staging blocks
- Bump version 1.5.1 → 1.5.2 across all 8 plugin manifests

## Test plan
- [ ] Run headless refresh against a corpus with new files — verify entries land in existing sections
- [ ] Confirm version is 1.5.2 in all manifests: `grep -r "1.5.2" --include="*.json" .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)