### PR TITLE
docs(patterns): sparse-checkout recipe + compare-API prohibition in git.md

### DIFF
--- a/docs/backlog/index.md
+++ b/docs/backlog/index.md
@@ -13,7 +13,7 @@ Statuses: `Proposed` → `Accepted` → `In progress` → `Done` (or `Rejected` 
 | 02 | [Result contract as file + shared index-update pattern](02-result-contract-and-shared-update-pattern.md) | **P2** | Done (PR #47) | S | — | Write `refresh-result.yaml` instead of parsing prose; extract the duplicated refresh algorithm into one pattern doc; surface `skipped-manual` local sources. |
 | 04 | [Python packaging (PEP 723 + uv), cache-path bug, CI](04-python-packaging-and-ci.md) | **P2** | Done (PR #47) | S | — | Self-contained `uv run` scripts, fix `FASTEMBED_CACHE_PATH` bug in detect.py, dedupe constants, add CI to the plugin repo. |
 | 03 | [Tiered v2 rendering → v1 migration → retire v1](03-retire-v1-tiered-v2-rendering.md) | **P3** | Proposed | L | internal sequencing | Make tiering a render-time concern of index.yaml, ship a migrate skill, move flyio off v1, delete v1 write paths. |
-| 05 | [Scheduler consolidation](05-scheduler-consolidation.md) | **P3** | Proposed | S | 01, 02, 04 | Replace 7 copy-pasted tasks with template+constants or a registry-driven task; upstream the sparse-checkout lesson into git.md; branch/PR hygiene. |
+| 05 | [Scheduler consolidation](05-scheduler-consolidation.md) | **P3** | In progress (wave 3) | S | 01, 02, 04 | Replace 7 copy-pasted tasks with template+constants or a registry-driven task; upstream the sparse-checkout lesson into git.md; branch/PR hygiene. |
 | 06 | [Decision capture + more headless surfaces](06-decision-capture-and-headless-surfaces.md) | P4 | Proposed | M | 02, 03 | Persist build decisions in config.yaml for replay; headless status/graph-validate; `embeddings_lag` observability. |
 
 ## Suggested sequencing

--- a/lib/corpus/patterns/sources/git.md
+++ b/lib/corpus/patterns/sources/git.md
@@ -262,6 +262,32 @@ compare_clone_to_indexed() {
 
 ---
 
+### Sparse Checkout for Large Repositories (and the compare-API prohibition)
+
+For large upstream repos — or whenever only `docs_root` matters — use a sparse,
+blob-filtered clone instead of a full one. The clone lives in `.source/{id}/`
+(gitignored) and persists between runs, so the clone cost is paid once;
+subsequent runs just fetch and diff locally.
+
+**Using bash:**
+```bash
+# First run — sparse clone of docs_root only
+git clone --filter=blob:none --sparse --depth=50 <repo_url> .source/<id>
+git -C .source/<id> sparse-checkout set <docs_root>
+git -C .source/<id> checkout <branch>
+
+# Subsequent runs — fetch and diff locally
+git -C .source/<id> fetch --depth=50 origin <branch>
+git -C .source/<id> diff --name-status <last_commit_sha>..FETCH_HEAD -- <docs_root>
+```
+
+**Never use the GitHub compare API**
+(`gh api repos/{owner}/{repo}/compare/{base}...{head}`) **for change
+detection.** It caps the returned file list at 300 entries and silently drops
+the rest — a large documentation refresh will miss changed files with no error
+or warning. This is an operational lesson learned in production (scheduled
+corpus refreshes): always diff locally inside the clone.
+
 ---
 
 ### Extraction Support

--- a/skills/hiivmind-corpus-refresh-headless/SKILL.md
+++ b/skills/hiivmind-corpus-refresh-headless/SKILL.md
@@ -99,8 +99,11 @@ run continues for other sources.
 
 `${CLAUDE_PLUGIN_ROOT}/lib/corpus/patterns/sources/git.md`:
 
-Clone to `.source/{id}` if not present (depth 50). Then ensure the tracked SHA is
-reachable for diffing:
+Clone to `.source/{id}` if not present (depth 50; for large repos prefer the
+sparse blob-filtered clone — see "Sparse Checkout for Large Repositories" in
+`patterns/sources/git.md`). Never use the GitHub compare API to list changed
+files: it caps at 300 files and silently truncates. Then ensure the tracked
+SHA is reachable for diffing:
 
 ```pseudocode
 DEEPEN_IF_NEEDED(clone_dir, source):


### PR DESCRIPTION
Part of backlog item 05 (scheduler consolidation, wave 3).

- New git.md section: sparse blob-filtered clone recipe for large repos, persisted in .source/{id}/
- Documents the GitHub compare API's 300-file silent-truncation limit and prohibits it for change detection (previously this lesson lived only in scheduler task files)
- refresh-headless Phase 3 points at the new section
- Backlog 05 → In progress

Companion PR in hiivmind-corpus-scheduler consolidates the seven tasks into a shared template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)