### PR TITLE
docs(plans): check in wave 2/3/4 implementation plans

### DIFF
--- a/docs/superpowers/plans/2026-07-09-wave2-tiered-v2-retire-v1.md
+++ b/docs/superpowers/plans/2026-07-09-wave2-tiered-v2-retire-v1.md
@@ -1,0 +1,772 @@
+# Wave 2: Tiered v2 Rendering, v1→v2 Migration, v1 Read-Only Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make tiering a render-time concern of `index.yaml` (one source of truth, N rendered files), ship a headless `hiivmind-corpus-migrate` skill, migrate flyio off v1 as the proving case, and declare v1 read-only in every write-path skill.
+
+**Architecture:** A `render:` block in config.yaml (`strategy: single | tiered`, section definitions, optional quick-reference list) plus an optional per-entry `section` field drive `render-index.sh` to emit `index.md` + `index-{section}.md` deterministically from one `index.yaml`. Migration is mechanical: parse v1 entry lines, cross-reference `.source/` for metadata, LLM-assign category/tags, emit index.yaml + render block, render, and diff-check ID parity against the original. v1 write paths are *marked read-only this release* (skills detect v1 → instruct migration); deletion happens next release per the backlog.
+
+**Tech Stack:** Markdown skills/patterns, bash + mikefarah yq v4 (render-index.sh), one small addition to `validate_result.py` (new `migrate` kind).
+
+## Global Constraints
+
+- Repo: `/Users/nathanielramm/git/hiivmind/hiivmind-corpus`, branch `feature/wave2-tiered-v2` off up-to-date main. flyio migration happens in `/Users/nathanielramm/git/hiivmind/hiivmind-corpus-flyio` on branch `migrate/v2` and needs the plugin work installed/available first — it is the LAST task.
+- Follow the repo convention (user feedback, wave 1): **skills and pattern docs first, Python last**; tests stay light — features first, verify by direct runs.
+- render-index.sh constraint: mikefarah yq v4 only — **no jq-style `if/then/else`** (lexer rejects it); use the existing hybrid yq-TSV + bash formatting approach and `env()` for variable passing.
+- Contract stays `contract_version: 1` — adding a new `kind` is backward-compatible (documented in `patterns/headless-contract.md` versioning policy).
+- v1 write logic is NOT deleted this wave — only gated. `patterns/index-updating.md` v1 sections get a deprecation banner but remain.
+- CLAUDE.md "Maintaining Skill Alignment": adding the migrate skill requires updating architecture tree, naming list, lifecycle diagram, cross-cutting table, dependency chain, and every skill's `## Reference` section.
+- Commits: conventional, ending `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`. PR bodies end with `🤖 Generated with [Claude Code](https://claude.com/claude-code)`.
+- Acceptance (backlog 03): flyio is v2 with tiered `index-*.md` rendered deterministically from one `index.yaml`; no skill *executes* v1 write logic; CLAUDE.md alignment table shrinks.
+
+---
+
+### Task 1: Schema — `render:` block and entry `section` field
+
+**Files:**
+- Modify: `lib/corpus/patterns/index-format-v2.md` (field table + new section)
+- Modify: `lib/corpus/patterns/config-parsing.md` (document the `render:` block)
+- Modify: `templates/config.yaml.template` (commented `render:` example near the `index:` block, ~line 50)
+
+**Interfaces:**
+- Produces: the `render:` schema and `section` entry field that Tasks 2 (renderer), 3 (migrate skill), and 5 (build skill) consume.
+
+- [ ] **Step 1: Add `section` to the entry field table in index-format-v2.md**
+
+After the `category` row in the Field Definitions table, add:
+
+```markdown
+| `section` | string | no | Render-time grouping key for tiered corpora. Must match a `render.sections[].id` in config.yaml. Entries without it render in the main index. Storage-agnostic: navigate/yq queries ignore it |
+```
+
+- [ ] **Step 2: Add the `render:` block documentation**
+
+In `lib/corpus/patterns/config-parsing.md`, add a new top-level section (after the sources documentation):
+
+````markdown
+## The `render:` Block (tiered rendering)
+
+Controls how `render-index.sh` turns `index.yaml` into markdown. Absent block =
+`strategy: single` (one index.md, current behavior). Tiering is a **render-time
+concern, not a storage concern** — there is exactly one `index.yaml` either way.
+
+```yaml
+render:
+  strategy: tiered            # single (default) | tiered
+  quick_reference:            # optional: entry IDs pinned at the top of index.md
+    - "flyio:flyctl/install.html.markerb"
+    - "flyio:getting-started/launch.html.markerb"
+  sections:                   # required when strategy: tiered
+    - id: getting-started     # slug; produces index-getting-started.md
+      title: "Getting Started"
+      description: "First steps - installation, signup, first deploy"
+    - id: machines
+      title: "Fly Machines"
+      description: "Machines lifecycle, REST API, flyctl commands"
+```
+
+Entries opt into a section via their `section:` field in index.yaml (see
+`index-format-v2.md`). Entries with no `section` (or one not listed here) render
+inline in the main index under their category. Deleting a section from this list
+does not lose data — its entries just fall back to the main index on next render.
+````
+
+Also add the same `render:` example as a commented block in `templates/config.yaml.template` under the `index:` section.
+
+- [ ] **Step 3: Verify and commit**
+
+```bash
+grep -n "render:" lib/corpus/patterns/config-parsing.md templates/config.yaml.template
+grep -n "section.*Render-time" lib/corpus/patterns/index-format-v2.md
+git add -A && git commit -m "docs(patterns): render: block schema and entry section field for tiered v2
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Tiered rendering in `render-index.sh` + `index-rendering.md`
+
+**Files:**
+- Modify (full rewrite): `templates/render-index.sh`
+- Modify: `lib/corpus/patterns/index-rendering.md` (algorithm + tiered rules)
+
+**Interfaces:**
+- Consumes: `render:` schema from Task 1.
+- Produces: `bash render-index.sh index.yaml` emitting `index.md` (+ `index-{id}.md` per section when tiered). Tasks 3 and 6 call it unchanged.
+
+- [ ] **Step 1: Replace templates/render-index.sh with the tiered-capable version**
+
+```bash
+#!/usr/bin/env bash
+# render-index.sh — Deterministic index.yaml → index.md renderer
+# Copied to corpus root during build/migrate. Used by build, refresh, and CI.
+#
+# Usage: bash render-index.sh index.yaml
+# Reads config.yaml from the same directory for corpus name, source count, and
+# the render: block (strategy: single | tiered).
+# Requires: yq 4.0+ (mikefarah/yq)
+
+set -euo pipefail
+
+INDEX_YAML="${1:?Usage: render-index.sh <path-to-index.yaml>}"
+DIR=$(dirname "$INDEX_YAML")
+CONFIG_YAML="${DIR}/config.yaml"
+
+[ -f "$INDEX_YAML" ] || { echo "Error: $INDEX_YAML not found" >&2; exit 1; }
+[ -f "$CONFIG_YAML" ] || { echo "Error: $CONFIG_YAML not found (needed for corpus name)" >&2; exit 1; }
+
+CORPUS_NAME=$(yq '.corpus.display_name // .corpus.name' "$CONFIG_YAML")
+SOURCE_COUNT=$(yq '.sources | length' "$CONFIG_YAML")
+ENTRY_COUNT=$(yq '.meta.entry_count' "$INDEX_YAML")
+GENERATED_AT=$(yq '.meta.generated_at' "$INDEX_YAML")
+STRATEGY=$(yq '.render.strategy // "single"' "$CONFIG_YAML")
+
+# Emit entry lines grouped by category (h2), for the subset selected by MODE:
+#   MODE=all                  every entry
+#   MODE=main                 entries with no .section (or empty)
+#   MODE=section SECTION=<id> entries with .section == <id>
+# Uses yq for extraction (TSV) and bash for formatting; mikefarah yq v4 has no
+# jq-style if/then/else, and env() avoids all quote-escaping issues.
+render_entries() {
+  local mode="$1" section="${2:-}"
+  local categories
+  categories=$(MODE="$mode" SECTION="$section" yq -r '
+    .entries
+    | map(select(
+        (env(MODE) == "all")
+        or (env(MODE) == "main" and (.section // "") == "")
+        or (env(MODE) == "section" and (.section // "") == env(SECTION))
+      ))
+    | .[].category
+  ' "$INDEX_YAML" | sort -u)
+
+  for CAT in $categories; do
+    echo ""
+    CAT_HEADING=$(echo "$CAT" | sed 's/\b\(.\)/\u\1/g')
+    echo "## ${CAT_HEADING}"
+    echo ""
+    MODE="$mode" SECTION="$section" CAT_FILTER="$CAT" yq -r '
+      .entries
+      | map(select(
+          ((env(MODE) == "all")
+           or (env(MODE) == "main" and (.section // "") == "")
+           or (env(MODE) == "section" and (.section // "") == env(SECTION)))
+          and .category == env(CAT_FILTER)
+        ))
+      | sort_by(.title)
+      | .[]
+      | [.title, .id, .summary, .size, (.grep_hint // ""), (.stale | tostring)]
+      | @tsv
+    ' "$INDEX_YAML" | while IFS=$'\t' read -r title id summary size grep_hint stale; do
+      line="- **${title}** \`${id}\` - ${summary}"
+      if [[ "$size" == "large" && -n "$grep_hint" ]]; then
+        line+=" ⚡ GREP - \`${grep_hint}\`"
+      fi
+      if [[ "$stale" == "true" ]]; then
+        line+=" ⏳ STALE"
+      fi
+      echo "$line"
+    done
+  done
+}
+
+count_section_entries() {
+  local section="$1"
+  SECTION="$section" yq -r '[.entries[] | select((.section // "") == env(SECTION))] | length' "$INDEX_YAML"
+}
+
+render_single() {
+  {
+    echo "# ${CORPUS_NAME} Documentation Index"
+    echo ""
+    echo "> Sources: ${SOURCE_COUNT} | Entries: ${ENTRY_COUNT} | Generated: ${GENERATED_AT}"
+    echo '> Generated from `index.yaml` — do not edit directly'
+    echo ""
+    echo "---"
+    render_entries all
+    echo ""
+    echo "---"
+    echo ""
+    echo "*Rendered from index.yaml at ${GENERATED_AT}*"
+  } > "${DIR}/index.md"
+  echo "Rendered ${DIR}/index.md (${ENTRY_COUNT} entries)"
+}
+
+render_tiered() {
+  local section_ids
+  section_ids=$(yq -r '.render.sections[].id' "$CONFIG_YAML")
+
+  # --- main index.md ---
+  {
+    echo "# ${CORPUS_NAME} Documentation Index"
+    echo ""
+    echo "> Sources: ${SOURCE_COUNT} | Entries: ${ENTRY_COUNT} | Generated: ${GENERATED_AT}"
+    echo '> Generated from `index.yaml` — do not edit directly'
+    echo ""
+    echo "This corpus uses a **tiered index**. Start here, then drill into the"
+    echo "sub-index files for detailed entries."
+    echo ""
+    echo "---"
+
+    # Quick reference (pinned entry IDs, in config order)
+    QR_COUNT=$(yq -r '.render.quick_reference // [] | length' "$CONFIG_YAML")
+    if [[ "$QR_COUNT" -gt 0 ]]; then
+      echo ""
+      echo "## Quick Reference"
+      echo ""
+      yq -r '.render.quick_reference[]' "$CONFIG_YAML" | while read -r qid; do
+        QID="$qid" yq -r '
+          .entries[] | select(.id == env(QID))
+          | [.title, .id, .summary] | @tsv
+        ' "$INDEX_YAML" | while IFS=$'\t' read -r title id summary; do
+          echo "- **${title}** \`${id}\` - ${summary}"
+        done
+      done
+      echo ""
+      echo "---"
+    fi
+
+    # Section summaries
+    for SID in $section_ids; do
+      S_TITLE=$(SID="$SID" yq -r '.render.sections[] | select(.id == env(SID)) | .title' "$CONFIG_YAML")
+      S_DESC=$(SID="$SID" yq -r '.render.sections[] | select(.id == env(SID)) | .description // ""' "$CONFIG_YAML")
+      N=$(count_section_entries "$SID")
+      echo ""
+      echo "## ${S_TITLE}"
+      [[ -n "$S_DESC" ]] && { echo "*${S_DESC}*"; echo ""; }
+      echo "→ See [index-${SID}.md](index-${SID}.md) for ${N} detailed entries"
+      echo ""
+      echo "---"
+    done
+
+    # Unsectioned entries render inline
+    MAIN_COUNT=$(yq -r '[.entries[] | select((.section // "") == "")] | length' "$INDEX_YAML")
+    if [[ "$MAIN_COUNT" -gt 0 ]]; then
+      render_entries main
+      echo ""
+      echo "---"
+    fi
+
+    echo ""
+    echo "*Rendered from index.yaml at ${GENERATED_AT}*"
+  } > "${DIR}/index.md"
+
+  # --- one sub-index per section ---
+  for SID in $section_ids; do
+    S_TITLE=$(SID="$SID" yq -r '.render.sections[] | select(.id == env(SID)) | .title' "$CONFIG_YAML")
+    {
+      echo "# ${CORPUS_NAME} — ${S_TITLE}"
+      echo ""
+      echo "> Part of the ${CORPUS_NAME} Documentation Index — back to [main index](index.md)"
+      echo '> Generated from `index.yaml` — do not edit directly'
+      echo ""
+      echo "---"
+      render_entries section "$SID"
+      echo ""
+      echo "---"
+      echo ""
+      echo "*Rendered from index.yaml at ${GENERATED_AT}*"
+    } > "${DIR}/index-${SID}.md"
+  done
+
+  # Remove sub-indexes for sections no longer defined (rename/removal hygiene)
+  for f in "${DIR}"/index-*.md; do
+    [ -e "$f" ] || continue
+    base=$(basename "$f" .md); sid="${base#index-}"
+    echo "$section_ids" | grep -qx "$sid" || rm "$f"
+  done
+
+  echo "Rendered ${DIR}/index.md + $(echo "$section_ids" | wc -w | tr -d ' ') sub-indexes (${ENTRY_COUNT} entries)"
+}
+
+if [[ "$STRATEGY" == "tiered" ]]; then
+  render_tiered
+else
+  render_single
+fi
+```
+
+- [ ] **Step 2: Smoke-test both strategies against a fixture in the scratchpad**
+
+Create a scratchpad dir with a minimal `config.yaml` (name + 1 source + `render:` tiered block with 2 sections + 1 quick_reference id) and an `index.yaml` with 4 entries: 2 in section A, 1 in section B, 1 unsectioned. Run:
+
+```bash
+bash templates/render-index.sh <scratchpad>/index.yaml
+ls <scratchpad>/          # expected: index.md, index-a.md, index-b.md
+```
+
+Verify: quick-ref entry pinned at top; section counts correct; unsectioned entry inline under its category; run twice → identical output (idempotent). Then delete section B from config, re-run, verify `index-b.md` is removed and B's entry falls back inline. Then set `strategy: single` (or remove `render:`), re-run, verify one `index.md` with all 4 entries and no sub-index files remain stale (note: single mode does not delete old sub-indexes — the migrate/build skill handles that transition; acceptable).
+
+- [ ] **Step 3: Update index-rendering.md**
+
+Add to the Rendering Algorithm section (after rule 7):
+
+```markdown
+8. **Tiered strategy** (`config.render.strategy: tiered`): the main `index.md`
+   carries the header, an optional Quick Reference (entry IDs from
+   `render.quick_reference`, in config order), one summary block per
+   `render.sections[]` (title, italic description, entry count, link to
+   `index-{id}.md`), and any unsectioned entries inline. Each section renders
+   to `index-{id}.md` with a backlink header and the same category-grouped
+   entry format. Sub-index files for sections removed from config are deleted
+   on render. Sections are ordered as listed in config; everything else stays
+   alphabetical.
+```
+
+Update the Prerequisites and Purpose lines to mention the `render:` block, and note in "When to Use" that refresh/enhance re-render both files whenever `index.yaml` changes — sub-indexes are never edited directly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add templates/render-index.sh lib/corpus/patterns/index-rendering.md
+git commit -m "feat(render): tiered index.md + index-{section}.md rendering from one index.yaml
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `hiivmind-corpus-migrate` skill (headless, result contract)
+
+**Files:**
+- Create: `skills/hiivmind-corpus-migrate/SKILL.md`
+- Modify: `lib/corpus/patterns/headless-contract.md` (add migrate-result.yaml schema)
+
+**Interfaces:**
+- Consumes: `render:` schema (Task 1), tiered renderer (Task 2), existing `patterns/headless-contract.md` conventions (result file at corpus root, gitignored, `contract_version: 1`).
+- Produces: skill writing `{corpus_root}/migrate-result.yaml` with `kind: migrate`; Task 7 adds the validator kind; Task 6 (flyio) executes it.
+
+- [ ] **Step 1: Write the skill**
+
+`skills/hiivmind-corpus-migrate/SKILL.md`, full content:
+
+````markdown
+---
+name: hiivmind-corpus-migrate
+description: >
+  Headless v1 → v2 index migration. Parses entry lines from index.md and
+  index-*.md, cross-references .source/ for metadata, emits index.yaml plus a
+  render: block, renders deterministically, and diff-checks ID parity against
+  the original. Writes migrate-result.yaml (headless contract). Triggers:
+  "migrate corpus", "migrate to v2", "convert index.md to index.yaml".
+---
+
+# Corpus Migrate (v1 → v2, Headless)
+
+Mechanical migration of a v1 corpus (`index.md` as source of truth, optionally
+tiered) to v2 (`index.yaml` + rendered markdown). Non-interactive: designed for
+pipelines and one-shot runs; decisions are deterministic or recorded in the
+result file for human review.
+
+**Inputs:**
+- `corpus_path` (required) — corpus repository root
+- `result_path` (optional) — defaults to `{corpus_path}/migrate-result.yaml`
+
+## State
+
+```yaml
+computed:
+  v1_files: []          # index.md + index-*.md found
+  parsed_entries: []    # {title, id, summary, grep_hint, stale, section, v1_heading}
+  sections: []          # {id, title, description} derived from sub-index files
+  skipped: []           # entries whose source file no longer exists
+  entry_count: 0
+  errors: []
+  error: null           # fatal → ABORT
+```
+
+## Phase 1: Validate
+
+Read `{corpus_path}/config.yaml` (see `patterns/config-parsing.md`).
+
+- ABORT if `index.yaml` already exists → "already v2 — nothing to migrate".
+- ABORT if no `index.md` → "no v1 index found".
+- Collect `computed.v1_files`: `index.md` plus every `index-*.md` at corpus root.
+- Detect tiering: >1 file → tiered v1.
+
+## Phase 2: Parse v1 Entries
+
+For each v1 file, extract entry lines with this exact shape (the v1 format):
+
+```
+- **{title}** `{id}` - {summary}[ ⚡ GREP - `{hint}`][ ⏳ STALE]
+```
+
+Regex: ``^- \*\*(.+?)\*\* `([^`]+)` - (.*)$`` then strip/capture the optional
+`⚡ GREP - `...`` and `⏳ STALE` suffixes from the summary tail.
+
+Record for each entry: `title`, `id`, `summary`, `grep_hint` (or null),
+`stale` (true if the ⏳ marker was present), `section` (the sub-index slug the
+line came from — `index-machines.md` → `machines`; null for entries in the
+main index, including Quick Reference duplicates — dedupe by `id`, sub-index
+wins), and `v1_heading` (the nearest preceding `## ` heading, kept as an
+extra tag).
+
+For each sub-index file, also record a section definition: `id` = file slug,
+`title` = the sub-index h1 (strip " - Detailed Index" suffixes) or the main
+index's corresponding `## ` heading, `description` = the italic line under
+that heading in the main index (or empty).
+
+If a main index lists a Quick Reference, record those entry IDs in order.
+
+ABORT if zero entries parse — the index is not in the expected v1 format.
+
+## Phase 3: Cross-Reference Sources
+
+Ensure each git source is cloned at `.source/{id}/` (sparse clone is fine —
+see "Sparse Checkout for Large Repositories" in `patterns/sources/git.md`).
+
+For each parsed entry, split `id` into `{source}:{path}` and resolve the file
+under `.source/{source}/{docs_root}/{path}` (fallback: `.source/{source}/{path}`).
+
+- File exists → collect: `content_type` (by extension), `size`
+  (`large` if >1000 lines, else `standard`), `headings` (h2s, slugified
+  anchors), line count.
+- File missing → move entry to `computed.skipped` with reason `file-missing`.
+  Do not invent entries.
+
+## Phase 4: Assemble index.yaml
+
+For each surviving entry, build a v2 entry per `patterns/index-format-v2.md`:
+`id`, `source`, `path`, `title`, `summary` (verbatim from v1), `tags`
+(LLM-assigned from title + summary + v1_heading; include the slugified
+v1_heading itself), `keywords` (LLM-assigned, function/command names from the
+title and summary), `concepts: []`, `category` (LLM judgment mapped to the
+enum: reference | tutorial | guide | api | config | navigation | journal —
+default `reference` when unclear), `content_type`, `size`, `grep_hint`,
+`section` (from Phase 2; omit if null), `headings`, `links_to: []`,
+`links_from: []`, `frontmatter: {}`, `stale` (from the v1 ⏳ marker),
+`stale_since: null`, `last_indexed: now()`.
+
+Set `meta.generated_at = now()`, `meta.entry_count`.
+
+## Phase 5: Render and Diff-Check
+
+1. Write the `render:` block into config.yaml: `strategy: tiered` when tiered
+   v1 (else `single`), `sections` from Phase 2 (config order = main-index
+   order), `quick_reference` from Phase 2 if present.
+2. Write `index.yaml`.
+3. Copy `${CLAUDE_PLUGIN_ROOT}/templates/render-index.sh` to the corpus root
+   (overwrite — the corpus needs the tiered-capable version).
+4. `bash render-index.sh index.yaml`.
+5. **Diff-check:** every entry ID present in the ORIGINAL v1 files must appear
+   in the rendered output (skipped entries excepted — they are reported, not
+   silently dropped). Extract IDs with `` grep -oh '`[a-z0-9-]*:[^`]*`' `` from
+   old and new files and compare as sets. Any ID missing from the render that
+   is not in `computed.skipped` → ABORT (do not commit a lossy migration).
+6. Update config metadata: `index.last_updated_at = now()`.
+
+Note: embeddings are NOT generated here — run build Phase 7 / enhance
+afterwards if the corpus should gain them. `migrate-result.yaml` reports
+`embeddings: skipped`.
+
+## Output Contract
+
+See `${CLAUDE_PLUGIN_ROOT}/lib/corpus/patterns/headless-contract.md`. Resolve
+`result_path` (default `{corpus_path}/migrate-result.yaml`), ensure the
+filename is in the corpus `.gitignore`, and Write:
+
+```yaml
+contract_version: 1
+kind: migrate
+corpus: {corpus name}
+run_at: {ISO 8601}
+entries_migrated: {int}
+entries_skipped:                 # file-missing etc. — human review items
+  - id: "flyio:old/path.md"
+    reason: file-missing
+sections: [{count} strings]      # section ids written to render.sections
+strategy: tiered | single
+id_parity: true                  # diff-check passed
+embeddings: skipped
+errors: []
+```
+
+Validate before finishing:
+`uv run ${CLAUDE_PLUGIN_ROOT}/lib/corpus/scripts/validate_result.py {result_path} --kind migrate`
+
+Write the result file even on ABORT (with `error` populated and
+`id_parity: false` where applicable).
+
+## Error Handling
+
+| Error | Handling |
+|-------|----------|
+| Already v2 | ABORT: "index.yaml exists — nothing to migrate" |
+| No index.md | ABORT: "no v1 index found" |
+| Zero entries parsed | ABORT: "index.md is not in v1 entry-line format" |
+| Source clone failed | Entries of that source → skipped (reason clone-failed); continue |
+| ID parity failure | ABORT — report missing IDs in result file |
+
+## Reference
+
+- Patterns: `config-parsing.md`, `index-format-v2.md`, `index-rendering.md`, `headless-contract.md`, `sources/git.md`
+- Related skills: hiivmind-corpus-build, hiivmind-corpus-refresh, hiivmind-corpus-refresh-headless, hiivmind-corpus-enrich-headless, hiivmind-corpus-enhance, hiivmind-corpus-status, hiivmind-corpus-navigate, hiivmind-corpus-graph, hiivmind-corpus-init, hiivmind-corpus-add-source, hiivmind-corpus-discover, hiivmind-corpus-register, hiivmind-corpus-bridge
+````
+
+- [ ] **Step 2: Add the migrate-result schema to headless-contract.md**
+
+In `lib/corpus/patterns/headless-contract.md`: add a row to the file-locations table (`hiivmind-corpus-migrate | migrate-result.yaml | {corpus_root}/migrate-result.yaml`), add the `### migrate-result.yaml` schema section (the YAML block from the skill's Output Contract above, with field comments: `entries_migrated`/`entries_skipped` required, `id_parity` required boolean, `strategy` enum, `embeddings` always `skipped` for migrate), and extend the validation example with `--kind migrate`. Note under versioning: "adding a kind is backward-compatible; consumers reject only unknown `contract_version`."
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/hiivmind-corpus-migrate/ lib/corpus/patterns/headless-contract.md
+git commit -m "feat(migrate): headless v1→v2 migration skill with result contract
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Mark v1 read-only in refresh, refresh-headless, and enhance
+
+**Files:**
+- Modify: `skills/hiivmind-corpus-refresh/SKILL.md` (Phase 1 format detection, ~lines 52-58)
+- Modify: `skills/hiivmind-corpus-refresh-headless/SKILL.md` (Phase 1 validation)
+- Modify: `skills/hiivmind-corpus-enhance/SKILL.md` (prerequisite validation)
+- Modify: `lib/corpus/patterns/index-updating.md` (deprecation banner on v1 sections)
+
+**Interfaces:**
+- Consumes: `hiivmind-corpus-migrate` (Task 3) as the instructed remedy.
+
+- [ ] **Step 1: Gate v1 in the three write-path skills**
+
+In each skill's format-detection/validation phase, where `index_format == "v1"` is detected, replace the "proceed with v1 handling" path with:
+
+- **refresh (interactive):** display
+  `"This corpus uses the legacy v1 index (index.md as source of truth). v1 is read-only as of this release — refresh no longer updates it. Run hiivmind-corpus-migrate first (mechanical, headless), then refresh normally."`
+  Offer: `"Run the migration now? [y/N]"` — if yes, CALL_SKILL hiivmind-corpus-migrate then re-enter refresh Phase 1; if no, EXIT without modifying anything.
+- **refresh-headless:** write the result file with `errors: ["v1-index: read-only — run hiivmind-corpus-migrate"]`, all sources `status: skipped-manual`, zero index_changes, and ABORT. (Contract unchanged — this reuses existing fields.)
+- **enhance:** same message as refresh, EXIT (no auto-offer — enhance sessions are topic-focused; migration is a separate decision).
+
+Keep the format-detection code itself — v1 must still be *recognized* to route to the message.
+
+- [ ] **Step 2: Banner in index-updating.md**
+
+At the top of the v1 sections of `lib/corpus/patterns/index-updating.md`, insert:
+
+```markdown
+> **DEPRECATED — v1 is read-only.** As of wave 2, no skill writes v1 indexes;
+> refresh/enhance detect v1 and instruct `hiivmind-corpus-migrate`. These rules
+> are retained for one release for reference and for the migrate skill's
+> understanding of the v1 entry-line format, then deleted.
+```
+
+- [ ] **Step 3: Verify and commit**
+
+```bash
+grep -n "read-only\|hiivmind-corpus-migrate" skills/hiivmind-corpus-refresh/SKILL.md skills/hiivmind-corpus-refresh-headless/SKILL.md skills/hiivmind-corpus-enhance/SKILL.md lib/corpus/patterns/index-updating.md
+git add -A && git commit -m "feat(refresh,enhance): v1 indexes are read-only — instruct migration
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Un-defer tiered v2 in build; derivation DAG pattern; consistency sweep; CLAUDE.md
+
+**Files:**
+- Modify: `skills/hiivmind-corpus-build/SKILL.md` (Phase 3 ~line 227-247, Phase 8 ~line 645-673)
+- Create: `lib/corpus/patterns/derivation-dag.md`
+- Modify: `skills/hiivmind-corpus-refresh-headless/SKILL.md` (source-type table, Phase 2/3: add `obsidian` row; note `pdf` is a pre-processing concern of `local`, not a source type)
+- Modify: `CLAUDE.md`
+- Modify: `commands/hiivmind-corpus.md` (Available Skills table: add migrate)
+- Modify: every other skill's `## Reference` / Related Skills list (add hiivmind-corpus-migrate): `init`, `add-source`, `build`, `enhance`, `refresh`, `refresh-headless`, `enrich-headless`, `discover`, `navigate`, `register`, `status`, `graph`, `bridge`
+
+**Interfaces:**
+- Consumes: renderer (Task 2), `render:` schema (Task 1).
+
+- [ ] **Step 1: Build Phase 3 — segmentation now writes render config**
+
+In the Phase 3 strategy table & follow-up, after "If tiered or by-source selected, collect section definitions from user." add:
+
+```markdown
+Record the decision as the `render:` block in config.yaml (see
+`patterns/config-parsing.md`): `strategy: tiered` with the collected
+`sections` (id, title, description), or `strategy: single`. "By source"
+is tiered with one section per source id. Section membership is written
+per-entry (`section:` field) during Phase 5 index generation, using the
+section definitions as assignment targets.
+```
+
+- [ ] **Step 2: Build Phase 8 — replace the deferred line**
+
+Old (line ~650): `4. If tiered: write each `index-{section}.md` sub-index file (v1 format only — tiered v2 is deferred)`
+
+New: `4. Run \`bash render-index.sh index.yaml\` — with \`render.strategy: tiered\` this also emits every \`index-{section}.md\` sub-index (see patterns/index-rendering.md); no hand-written sub-indexes, ever.`
+
+(Also delete the now-redundant separate step 3/4 split if it duplicates the render call — steps become: write index.yaml → copy render-index.sh → render.)
+
+- [ ] **Step 3: Create patterns/derivation-dag.md**
+
+```markdown
+# Pattern: Derivation DAG — what skills write vs what is derived
+
+## The Rule
+
+Skills only ever WRITE three files: `config.yaml`, `index.yaml`, `graph.yaml`.
+Everything else in a corpus repository is a DERIVED ARTIFACT, regenerated
+mechanically from those three:
+
+```
+config.yaml ─┐
+             ├─→ render-index.sh ─→ index.md, index-{section}.md
+index.yaml ──┤
+             ├─→ embed.py ────────→ index-embeddings.lance/
+graph.yaml ──┘                      chunks-embeddings.lance/
+```
+
+- `index.md` and every `index-*.md`: rendered by `render-index.sh`
+  (patterns/index-rendering.md). Never hand-edited, never LLM-written.
+- `*.lance/` embeddings: generated by `embed.py` from index.yaml (+ graph
+  concepts). Regenerable at any time from the sources of truth.
+- Result files (`*-result.yaml`): run outputs, gitignored, not corpus state.
+
+## Why
+
+One source of truth per fact. A hand edit to a derived file is lost on the
+next render — if information belongs in the corpus, it goes in index.yaml
+(entries), config.yaml (sources, render, build decisions), or graph.yaml
+(concepts). The v1 format violated this (index.md was both storage and
+presentation) and is read-only as of wave 2.
+
+## Skill Checklist
+
+| Skill | Writes | Renders/derives after |
+|-------|--------|-----------------------|
+| build | config.yaml, index.yaml, graph.yaml | render-index.sh, embed.py |
+| refresh / refresh-headless | config.yaml, index.yaml | render-index.sh, embed.py |
+| enhance | index.yaml, graph.yaml | render-index.sh, embed.py |
+| enrich-headless | index.yaml | render-index.sh, embed.py |
+| migrate | config.yaml, index.yaml | render-index.sh |
+| graph | graph.yaml | embed.py (if concept text changed) |
+| navigate / status / discover | nothing | — |
+
+## Related Patterns
+
+- index-rendering.md, index-format-v2.md, embeddings.md, headless-contract.md
+```
+
+- [ ] **Step 4: Source-type consistency sweep**
+
+In `skills/hiivmind-corpus-refresh-headless/SKILL.md` Phase 2 detection table and Phase 3 "Other source types" list, add: `**Obsidian:** same as git when vault is a clone (`.source/{id}/`), or timestamp scan for direct local paths — see patterns/sources/obsidian.md`. Check `skills/hiivmind-corpus-refresh/SKILL.md` for the same gap and fix identically. PDF needs no row (it is `local`-source pre-processing per `sources/README.md`), but add that one-line clarification to the README taxonomy table's footnote.
+
+- [ ] **Step 5: CLAUDE.md and reference sweeps**
+
+In `CLAUDE.md`:
+- Architecture tree + Naming Convention + Skill Lifecycle: add `hiivmind-corpus-migrate` (build-side, "one-shot v1→v2").
+- Pattern table: add `derivation-dag.md` row.
+- Key Design Decisions: add "**Tiering is render-time**: one index.yaml; `render:` block drives single vs tiered output. v1 is read-only legacy (migrate skill)."
+- Cross-cutting table: collapse "Tiered indexes | build, enhance, refresh | Detection logic, update handling" to "Tiered rendering | build, migrate, refresh (re-render only) | `render:` block, section field — patterns/index-rendering.md"; update the "Index updating" row's skill list to note v1 is read-only.
+- Dependency chain: add `migrate ──► index.yaml + render-index.sh (one-shot v1→v2)`.
+
+In `commands/hiivmind-corpus.md`: add the migrate row to Available Skills.
+
+Add `hiivmind-corpus-migrate` to every skill's Reference/Related Skills section (13 skills listed in Files above).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "feat(build): tiered v2 via render config; derivation-dag pattern; migrate skill wiring
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6 (Python tail): `validate_result.py` migrate kind + backlog + PR
+
+**Files:**
+- Modify: `lib/corpus/scripts/validate_result.py`
+- Modify: `lib/corpus/scripts/tests/test_validate_result.py` (one test)
+- Modify: `docs/backlog/index.md` (03 → In progress)
+
+**Interfaces:**
+- Consumes: migrate-result schema (Task 3). Existing internals: `validate(data, kind) -> list[str]` with `_require()` helper; kind enums at module top.
+
+- [ ] **Step 1: Add the migrate kind**
+
+In `validate_result.py`: add `"migrate"` to the CLI `--kind` choices and a `_validate_migrate(data, errors)` branch checking: `entries_migrated` int required; `entries_skipped` list required (each item needs `id` and `reason` strings); `sections` list of strings required; `strategy` in `{"tiered", "single"}`; `id_parity` bool required; `embeddings` == `"skipped"`; plus the shared header checks (contract_version 1, kind match, corpus, run_at, errors list) already applied by `validate()`.
+
+- [ ] **Step 2: One test + suite**
+
+Add to `test_validate_result.py` a `test_valid_migrate_result` mirroring the existing valid-refresh test with the YAML block from Task 3's Output Contract. Run:
+
+```bash
+uv run --group dev pytest lib/corpus/scripts/tests/test_validate_result.py -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Backlog, full suite, push, PR**
+
+Set backlog 03 → `In progress (wave 2)`. Then:
+
+```bash
+uv run --group dev pytest -q -m "not model"       # expected: all pass
+git add -A && git commit -m "feat(contract): migrate kind in validate_result; backlog 03 in progress
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+git push -u origin feature/wave2-tiered-v2
+gh pr create --title "feat: tiered v2 rendering, migrate skill, v1 read-only (backlog 03)" --body "$(cat <<'EOF'
+Implements backlog item 03 (docs/backlog/03-retire-v1-tiered-v2-rendering.md), waves: rendering → migration → read-only gating. v1 write-path deletion is deliberately deferred one release.
+
+- render: config block + entry section field; render-index.sh emits index.md + index-{section}.md from one index.yaml (tiering is render-time)
+- New headless hiivmind-corpus-migrate skill (v1→v2, ID-parity diff-check, migrate-result.yaml contract kind)
+- refresh / refresh-headless / enhance now treat v1 as read-only and instruct migration
+- patterns/derivation-dag.md names the write-vs-derived rule; obsidian added to refresh type tables
+- Build Phase 8 "tiered v2 is deferred" removed; segmentation decisions persist as the render: block
+
+Proving-case migration of hiivmind-corpus-flyio follows in that repo once this merges.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+### Task 7: Migrate flyio (proving case — AFTER the plugin PR merges and the installed plugin updates)
+
+**Files:** all in `/Users/nathanielramm/git/hiivmind/hiivmind-corpus-flyio` — creates `index.yaml`, `render-index.sh`, rewrites `index.md` + 8 sub-indexes, adds `render:` block to `config.yaml`, gitignores `migrate-result.yaml`.
+
+**Interfaces:**
+- Consumes: the released migrate skill (Task 3) and renderer (Task 2). Precondition: the *installed* hiivmind-corpus plugin includes this wave.
+
+- [ ] **Step 1: Branch and run the migration**
+
+```bash
+cd /Users/nathanielramm/git/hiivmind/hiivmind-corpus-flyio
+git checkout main && git pull && git checkout -b migrate/v2
+```
+
+Invoke `hiivmind-corpus-migrate` with `corpus_path: /Users/nathanielramm/git/hiivmind/hiivmind-corpus-flyio`. Expect: ~9 v1 files parsed, 8 sections + quick_reference derived, sparse clone of superfly/docs into `.source/flyio/`, entries with missing files reported as skipped (upstream moved files since 2026-07-02 — expected).
+
+- [ ] **Step 2: Validate the result and the acceptance criteria**
+
+```bash
+uv run <plugin>/lib/corpus/scripts/validate_result.py migrate-result.yaml --kind migrate   # exit 0
+yq '.render.strategy' config.yaml            # "tiered"
+yq '.meta.entry_count' index.yaml            # > 0, ≈ v1 entry count minus skipped
+ls index-*.md                                # 8 files matching render.sections ids
+bash render-index.sh index.yaml && git diff --stat index*.md   # idempotent: no diff on re-render
+```
+
+Navigational equivalence spot-check: pick 5 entry IDs from the OLD index (use `git show main:index-machines.md`), confirm each appears in the new rendered output with the same title and summary.
+
+- [ ] **Step 3: Commit, push, PR; report skipped entries for human review**
+
+```bash
+git add -A && git commit -m "feat: migrate index to v2 (index.yaml + tiered rendering)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+git push -u origin migrate/v2
+gh pr create --title "Migrate to v2 index (tiered rendering from index.yaml)" --body "<summary: entries migrated/skipped with reasons, sections, id_parity result>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+List `entries_skipped` in the PR body — these are the only human-judgment items. After merge: flip backlog 03 → Done, and note in `docs/backlog/index.md` that v1 write-path *deletion* is the follow-up for the next release.

--- a/docs/superpowers/plans/2026-07-09-wave3-scheduler-consolidation.md
+++ b/docs/superpowers/plans/2026-07-09-wave3-scheduler-consolidation.md
@@ -1,0 +1,583 @@
+# Wave 3: Scheduler Consolidation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Collapse the seven copy-pasted scheduler tasks into one shared template + seven thin stubs, upstream the sparse-checkout/compare-API lesson into the plugin's `git.md` pattern, add branch/PR hygiene, and delete the redundant per-task pyprojects.
+
+**Architecture:** Chosen model (user decision 2026-07-09): **shared template + thin stubs** — each `corpus-refresh-{name}/SKILL.md` shrinks to frontmatter + a 3-value Constants block + a pointer to `TEMPLATE-corpus-refresh.md` at the scheduler repo root. Directory names are preserved so the existing `~/.claude/scheduled-tasks/` symlinks and per-corpus schedules keep working untouched. The template gains branch/PR hygiene (detect superseded `automated/*` PRs, close them after the new PR lands, report unmerged-PR age). The hard-won git constraint moves into the plugin's `lib/corpus/patterns/sources/git.md`; the template keeps a one-line pointer.
+
+**Tech Stack:** Markdown skill files only (no Python). Verification is structural: `diff`, `grep`, symlink resolution.
+
+## Global Constraints
+
+- Two repos, two branches, two PRs:
+  - Plugin repo `/Users/nathanielramm/git/hiivmind/hiivmind-corpus` → branch `feature/wave3-git-sparse-checkout`
+  - Scheduler repo `/Users/nathanielramm/git/hiivmind/hiivmind-corpus-scheduler` → branch `feature/wave3-consolidate-template` (scheduler origin enforces "changes via PR"; local main was pushed to origin at c5eadf1 before this plan)
+- Task directory names (`corpus-refresh-atproto` … `corpus-refresh-lancedb`) must NOT change — symlinks in `~/.claude/scheduled-tasks/` point at them by name.
+- The template must be referenced by **absolute path** (`/Users/nathanielramm/git/hiivmind/hiivmind-corpus-scheduler/TEMPLATE-corpus-refresh.md`) — the routines runtime may read stubs through the symlink, where a relative `..` would resolve to `~/.claude/scheduled-tasks/`.
+- `archive/` in the scheduler repo is untouched (including its pyproject.toml).
+- Commit messages: conventional commits, ending with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- No force-push. PR bodies end with `🤖 Generated with [Claude Code](https://claude.com/claude-code)`.
+- Acceptance (from backlog 05): adding a corpus = one stub file; a process change edits exactly one file (the template); `git.md` documents the compare-API limitation.
+
+---
+
+### Task 1: Upstream the git constraint into the plugin (`git.md` + refresh-headless pointer)
+
+**Files:**
+- Modify: `lib/corpus/patterns/sources/git.md` (insert new section after "Compare Clone to Indexed SHA", i.e. after the `**Return values:**` list around line 261, before `### Extraction Support`)
+- Modify: `skills/hiivmind-corpus-refresh-headless/SKILL.md:100-115` (Phase 3 "Git source update")
+- Modify: `docs/backlog/index.md` (item 05 status)
+
+**Interfaces:**
+- Produces: a `### Sparse Checkout for Large Repositories (and the compare-API prohibition)` heading in `git.md` that Task 2's template pointer cites by name.
+
+- [ ] **Step 1: Create the plugin branch**
+
+```bash
+cd /Users/nathanielramm/git/hiivmind/hiivmind-corpus
+git checkout main && git pull
+git checkout -b feature/wave3-git-sparse-checkout
+```
+
+- [ ] **Step 2: Add the sparse-checkout section to git.md**
+
+In `lib/corpus/patterns/sources/git.md`, immediately after the "Compare Clone to Indexed SHA" section's `**Return values:**` list (and the `---` separators that follow it, ~line 263), insert:
+
+```markdown
+### Sparse Checkout for Large Repositories (and the compare-API prohibition)
+
+For large upstream repos — or whenever only `docs_root` matters — use a sparse,
+blob-filtered clone instead of a full one. The clone lives in `.source/{id}/`
+(gitignored) and persists between runs, so the clone cost is paid once;
+subsequent runs just fetch and diff locally.
+
+**Using bash:**
+```bash
+# First run — sparse clone of docs_root only
+git clone --filter=blob:none --sparse --depth=50 <repo_url> .source/<id>
+git -C .source/<id> sparse-checkout set <docs_root>
+git -C .source/<id> checkout <branch>
+
+# Subsequent runs — fetch and diff locally
+git -C .source/<id> fetch --depth=50 origin <branch>
+git -C .source/<id> diff --name-status <last_commit_sha>..FETCH_HEAD -- <docs_root>
+```
+
+**Never use the GitHub compare API**
+(`gh api repos/{owner}/{repo}/compare/{base}...{head}`) **for change
+detection.** It caps the returned file list at 300 entries and silently drops
+the rest — a large documentation refresh will miss changed files with no error
+or warning. This is an operational lesson learned in production (scheduled
+corpus refreshes): always diff locally inside the clone.
+
+---
+```
+
+(Keep the surrounding `---` separators balanced: one `---` before `### Extraction Support` must remain.)
+
+- [ ] **Step 3: Add the pointer in refresh-headless Phase 3**
+
+In `skills/hiivmind-corpus-refresh-headless/SKILL.md`, the "Git source update" subsection currently reads:
+
+```markdown
+Clone to `.source/{id}` if not present (depth 50). Then ensure the tracked SHA is
+reachable for diffing:
+```
+
+Replace with:
+
+```markdown
+Clone to `.source/{id}` if not present (depth 50; for large repos prefer the
+sparse blob-filtered clone — see "Sparse Checkout for Large Repositories" in
+`patterns/sources/git.md`). Never use the GitHub compare API to list changed
+files: it caps at 300 files and silently truncates. Then ensure the tracked
+SHA is reachable for diffing:
+```
+
+- [ ] **Step 4: Flip backlog 05 status**
+
+In `docs/backlog/index.md`, change item 05's Status cell from `Proposed` to `In progress (wave 3)`.
+
+- [ ] **Step 5: Verify**
+
+```bash
+grep -n "compare API\|compare-API\|Sparse Checkout" lib/corpus/patterns/sources/git.md skills/hiivmind-corpus-refresh-headless/SKILL.md
+```
+
+Expected: the new section heading in git.md, the prohibition text in both files.
+
+- [ ] **Step 6: Commit, push, PR**
+
+```bash
+git add lib/corpus/patterns/sources/git.md skills/hiivmind-corpus-refresh-headless/SKILL.md docs/backlog/index.md
+git commit -m "docs(patterns): upstream sparse-checkout recipe and compare-API prohibition into git.md
+
+The 300-file silent-truncation limit of the GitHub compare API was a
+hard-won scheduler lesson living only in scheduler task files. Document
+it where all refresh consumers can see it.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+git push -u origin feature/wave3-git-sparse-checkout
+gh pr create --title "docs(patterns): sparse-checkout recipe + compare-API prohibition in git.md" --body "$(cat <<'EOF'
+Part of backlog item 05 (scheduler consolidation, wave 3).
+
+- New git.md section: sparse blob-filtered clone recipe for large repos, persisted in .source/{id}/
+- Documents the GitHub compare API's 300-file silent-truncation limit and prohibits it for change detection (previously this lesson lived only in scheduler task files)
+- refresh-headless Phase 3 points at the new section
+- Backlog 05 → In progress
+
+Companion PR in hiivmind-corpus-scheduler consolidates the seven tasks into a shared template.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+### Task 2: Create `TEMPLATE-corpus-refresh.md` in the scheduler repo
+
+**Files:**
+- Create: `/Users/nathanielramm/git/hiivmind/hiivmind-corpus-scheduler/TEMPLATE-corpus-refresh.md`
+
+**Interfaces:**
+- Consumes: the `git.md` section heading from Task 1 (pointer only — no hard dependency at runtime).
+- Produces: the template file whose absolute path Task 3's stubs reference. State keys used by later phases: `computed.stale_branches` (list of `{branch, pr_number, pr_age_days}`), `computed.superseded_prs` (list of closed PR numbers).
+
+- [ ] **Step 1: Create the scheduler branch**
+
+```bash
+cd /Users/nathanielramm/git/hiivmind/hiivmind-corpus-scheduler
+git checkout main && git pull
+git checkout -b feature/wave3-consolidate-template
+```
+
+- [ ] **Step 2: Create the template from the lancedb task**
+
+```bash
+cp corpus-refresh-lancedb/SKILL.md TEMPLATE-corpus-refresh.md
+```
+
+Then apply the following exact edits to `TEMPLATE-corpus-refresh.md`:
+
+**Edit 2a — replace the frontmatter and intro** (lines 1–15, everything up to and including the first `---` separator after the blockquote):
+
+Old:
+```markdown
+---
+name: corpus-refresh-lancedb
+description: >
+---
+
+# Corpus Refresh — Scheduled Task
+
+Automated refresh of a corpus repository. Delegates the actual refresh work to the headless
+refresh skill, then handles branching, committing, and PR creation.
+
+No user present — act autonomously, note judgment calls, end with `<run-summary>`.
+
+> **To schedule a new corpus:** copy this skill directory, change only the Constants block
+> below, and symlink into `~/.claude/scheduled-tasks/`. Everything else is derived.
+```
+
+New:
+```markdown
+# Corpus Refresh — Shared Task Template
+
+Automated refresh of a corpus repository. Delegates the actual refresh work to the headless
+refresh skill, then handles branching, committing, and PR creation.
+
+No user present — act autonomously, note judgment calls, end with `<run-summary>`.
+
+> **This is not a runnable task.** It is the single source of truth executed by the thin
+> per-corpus stubs (`corpus-refresh-*/SKILL.md`), which supply the Constants. To schedule
+> a new corpus: create a stub directory with a SKILL.md containing only frontmatter, a
+> Constants block, and a pointer to this file, then symlink it into
+> `~/.claude/scheduled-tasks/`. A process change edits this file only — never the stubs.
+```
+
+**Edit 2b — replace the Constants section:**
+
+Old:
+```markdown
+## Constants
+
+```yaml
+CORPUS_PATH: /Users/nathanielramm/git/hiivmind/hiivmind-corpus-lancedb
+CORPUS_REPO: hiivmind/hiivmind-corpus-lancedb
+BRANCH_PREFIX: automated/corpus-refresh-lancedb
+```
+```
+
+New:
+```markdown
+## Constants
+
+Provided by the invoking stub's Constants block:
+
+```yaml
+CORPUS_PATH: # absolute path to the local corpus clone
+CORPUS_REPO: # owner/name on GitHub
+BRANCH_PREFIX: # e.g. automated/corpus-refresh-{name}
+```
+```
+
+**Edit 2c — update State** (add hygiene keys; `stale_branch` becomes a list):
+
+Old:
+```yaml
+  branch_name: null
+  stale_branch: null
+```
+
+New:
+```yaml
+  branch_name: null
+  stale_branches: []           # [{branch, pr_number, pr_age_days}] — unmerged automated/* branches
+  superseded_prs: []           # PR numbers closed as superseded by this run's PR
+```
+
+**Edit 2d — replace the sparse-checkout blockquote in Phase 3** (the 17-line `> **Git source constraint:** …` block including its fenced bash example):
+
+New (single short block in its place):
+```markdown
+> **Git source constraint:** follow the sparse-checkout recipe in the plugin's
+> `lib/corpus/patterns/sources/git.md` ("Sparse Checkout for Large Repositories").
+> Never use the GitHub compare API for change detection — it caps at 300 files and
+> silently drops the rest. Clone sparse into `.source/<id>/` (persists between runs,
+> gitignored) and use local `git diff`.
+```
+
+**Edit 2e — replace the stale-branch paragraph in Phase 2:**
+
+Old:
+```markdown
+Check for existing branches matching `BRANCH_PREFIX*`. If any have unmerged commits,
+log them for the summary but proceed with a fresh branch.
+```
+
+New:
+````markdown
+Detect leftover automated branches and their PRs:
+
+```pseudocode
+STALE_BRANCHES():
+  branches = Bash("git branch -r --list 'origin/" + BRANCH_PREFIX + "*'")
+  FOR b IN branches:
+    pr = Bash("gh pr list --repo " + CORPUS_REPO + " --head " + strip_origin(b)
+              + " --state open --json number,createdAt")
+    IF pr not empty:
+      computed.stale_branches += { branch: strip_origin(b),
+                                   pr_number: pr[0].number,
+                                   pr_age_days: days_between(pr[0].createdAt, now()) }
+    ELSE IF b has commits not on main:
+      computed.stale_branches += { branch: strip_origin(b), pr_number: null, pr_age_days: null }
+```
+
+Proceed with a fresh branch regardless — superseded PRs are closed in Phase 4
+*after* the new PR exists, never before.
+````
+
+**Edit 2f — add supersede handling at the end of Phase 4** (after the `gh pr create` line, before the `---` separator):
+
+```markdown
+After the new PR is created successfully, close superseded automated PRs — each open
+PR recorded in `computed.stale_branches` was generated by an earlier run from an older
+upstream state, and this run's PR (regenerated from current main and current upstream)
+replaces it:
+
+```pseudocode
+SUPERSEDE():
+  FOR s IN computed.stale_branches WHERE s.pr_number != null:
+    Bash("gh pr close " + s.pr_number + " --repo " + CORPUS_REPO
+         + " --comment 'Superseded by " + computed.pr_url + " (regenerated from current upstream).'"
+         + " --delete-branch")
+    computed.superseded_prs += s.pr_number
+```
+
+If this run creates no PR (no changes), leave existing PRs open — they still carry
+unmerged work — and only report their age in the summary.
+```
+
+**Edit 2g — extend SUMMARY:**
+
+Old:
+```markdown
+Always reached. Report: sources checked/updated, index change counts, embedding status,
+PR URL or "already current", any stale branches noted, any errors.
+```
+
+New:
+```markdown
+Always reached. Report: sources checked/updated, index change counts, embedding status,
+PR URL or "already current", superseded PRs closed (numbers), and for any automated PR
+left open its age in days (e.g. `stale automated PR: #12 (9 days old)`), any errors.
+```
+
+**Edit 2h — update the State Flow diagram footer**: in the `Phase 2` column of the State Flow table at the bottom, change `.stale_branch` to `.stale_branches`, and add `.superseded_prs` under the `Phase 4` column.
+
+- [ ] **Step 3: Verify the template**
+
+```bash
+grep -c "corpus-refresh-lancedb\|hiivmind-corpus-lancedb" TEMPLATE-corpus-refresh.md
+```
+
+Expected: `0` (no corpus-specific residue).
+
+```bash
+grep -n "stale_branches\|superseded_prs\|Sparse Checkout" TEMPLATE-corpus-refresh.md
+```
+
+Expected: hits in State, Phase 2, Phase 4, SUMMARY, and the Phase 3 pointer.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add TEMPLATE-corpus-refresh.md
+git commit -m "feat: shared corpus-refresh template with branch/PR hygiene
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Rewrite the seven task SKILL.md files as thin stubs
+
+**Files:**
+- Modify (full rewrite): `corpus-refresh-atproto/SKILL.md`, `corpus-refresh-data/SKILL.md`, `corpus-refresh-fastmail/SKILL.md`, `corpus-refresh-flyio/SKILL.md`, `corpus-refresh-frictionless/SKILL.md`, `corpus-refresh-github/SKILL.md`, `corpus-refresh-lancedb/SKILL.md`
+
+**Interfaces:**
+- Consumes: `/Users/nathanielramm/git/hiivmind/hiivmind-corpus-scheduler/TEMPLATE-corpus-refresh.md` (Task 2).
+- Produces: seven stubs differing only in the `{name}` substitution.
+
+- [ ] **Step 1: Write each stub**
+
+Exact content, with `{name}` ∈ {atproto, data, fastmail, flyio, frictionless, github, lancedb}:
+
+```markdown
+---
+name: corpus-refresh-{name}
+description: Scheduled refresh of the {name} corpus — delegates to the shared corpus-refresh template
+---
+
+# Corpus Refresh — {name}
+
+## Constants
+
+```yaml
+CORPUS_PATH: /Users/nathanielramm/git/hiivmind/hiivmind-corpus-{name}
+CORPUS_REPO: hiivmind/hiivmind-corpus-{name}
+BRANCH_PREFIX: automated/corpus-refresh-{name}
+```
+
+## Task
+
+Read and execute the shared template with the Constants above:
+
+`/Users/nathanielramm/git/hiivmind/hiivmind-corpus-scheduler/TEMPLATE-corpus-refresh.md`
+
+Every phase, constraint, and output contract is defined there. Do not deviate
+from it and do not improvise steps that are not in the template.
+```
+
+Write it with a loop to guarantee uniformity:
+
+```bash
+for name in atproto data fastmail flyio frictionless github lancedb; do
+cat > corpus-refresh-$name/SKILL.md <<EOF
+---
+name: corpus-refresh-$name
+description: Scheduled refresh of the $name corpus — delegates to the shared corpus-refresh template
+---
+
+# Corpus Refresh — $name
+
+## Constants
+
+\`\`\`yaml
+CORPUS_PATH: /Users/nathanielramm/git/hiivmind/hiivmind-corpus-$name
+CORPUS_REPO: hiivmind/hiivmind-corpus-$name
+BRANCH_PREFIX: automated/corpus-refresh-$name
+\`\`\`
+
+## Task
+
+Read and execute the shared template with the Constants above:
+
+\`/Users/nathanielramm/git/hiivmind/hiivmind-corpus-scheduler/TEMPLATE-corpus-refresh.md\`
+
+Every phase, constraint, and output contract is defined there. Do not deviate
+from it and do not improvise steps that are not in the template.
+EOF
+done
+```
+
+- [ ] **Step 2: Verify uniformity and symlink integrity**
+
+```bash
+for t in atproto data fastmail flyio frictionless github; do
+  diff <(sed "s/$t/NAME/g" corpus-refresh-$t/SKILL.md) <(sed 's/lancedb/NAME/g' corpus-refresh-lancedb/SKILL.md)
+done
+```
+
+Expected: no output (stubs identical modulo name).
+
+```bash
+ls -la ~/.claude/scheduled-tasks/ && cat ~/.claude/scheduled-tasks/corpus-refresh-lancedb/SKILL.md | head -4
+```
+
+Expected: all seven symlinks still resolve; the stub content is served through the symlink.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add corpus-refresh-*/SKILL.md
+git commit -m "refactor: replace seven copied task bodies with thin stubs over the shared template
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Delete per-task pyprojects and update scheduler CLAUDE.md
+
+**Files:**
+- Delete: `corpus-refresh-{atproto,data,fastmail,flyio,frictionless,github,lancedb}/pyproject.toml`
+- Modify: `/Users/nathanielramm/git/hiivmind/hiivmind-corpus-scheduler/CLAUDE.md` (full rewrite of Structure, Common tasks, Dependencies sections)
+
+**Interfaces:**
+- Consumes: PEP 723 script metadata shipped in plugin PR #47 (`uv run` resolves script deps; per-task venvs unnecessary).
+
+- [ ] **Step 1: Delete the pyprojects (archive untouched)**
+
+```bash
+git rm corpus-refresh-*/pyproject.toml
+ls corpus-refresh-*/          # expected: SKILL.md only, in each
+ls archive/templates/corpus-refresh/   # expected: pyproject.toml still present
+```
+
+- [ ] **Step 2: Rewrite CLAUDE.md**
+
+Replace the full contents of `CLAUDE.md` with:
+
+```markdown
+# hiivmind-corpus-scheduler
+
+Repository of scheduled tasks for automated corpus maintenance. Each subdirectory is a
+self-contained Claude Code Routine that gets symlinked into `~/.claude/scheduled-tasks/`.
+
+## Structure
+
+```
+TEMPLATE-corpus-refresh.md   # the single task definition: all phases, constraints, output contract
+corpus-refresh-{name}/       # one thin stub per corpus
+  SKILL.md                   # frontmatter + Constants (3 values) + pointer to the template
+```
+
+All process logic lives in `TEMPLATE-corpus-refresh.md`. Stubs supply only
+`CORPUS_PATH`, `CORPUS_REPO`, and `BRANCH_PREFIX`.
+
+## Deployment
+
+Tasks are symlinked from this repo into the routines directory:
+
+```bash
+ln -s /Users/nathanielramm/git/hiivmind/hiivmind-corpus-scheduler/{task-name} \
+      ~/.claude/scheduled-tasks/{task-name}
+```
+
+Never copy files into `~/.claude/scheduled-tasks/` — always symlink so changes in
+this repo propagate automatically.
+
+## Dependencies
+
+No per-task pyprojects. The plugin's Python scripts carry PEP 723 inline metadata and
+are invoked with `uv run ${CLAUDE_PLUGIN_ROOT}/lib/corpus/scripts/<script>.py` — uv
+resolves each script's dependencies into a cached ephemeral environment.
+
+The fastembed model cache at `~/.cache/fastembed/` must be accessible to the routine
+runtime. The model (`BAAI/bge-small-en-v1.5`, ~45MB) is downloaded on first use;
+tasks skip embedding if the model isn't already cached.
+
+## Common tasks
+
+- **Add a new corpus refresh:** create `corpus-refresh-{name}/SKILL.md` by copying any
+  existing stub and substituting the corpus name (three Constants + frontmatter), then
+  symlink into `~/.claude/scheduled-tasks/`. Nothing else.
+- **Change the refresh process:** edit `TEMPLATE-corpus-refresh.md` only. Stubs never
+  change.
+- **Update the headless refresh logic:** edit
+  `hiivmind-corpus/skills/hiivmind-corpus-refresh-headless/SKILL.md` — the template
+  delegates to it via CALL_SKILL. The template reads `refresh-result.yaml` /
+  `enrich-result.yaml` result files from the corpus root and validates them with
+  `validate_result.py` (see the plugin's `patterns/headless-contract.md`); the
+  refresh → enrich-headless sequence is mandatory when stale entries exist.
+- **Git source operations:** the sparse-checkout recipe and the GitHub compare-API
+  prohibition are documented in the plugin's `lib/corpus/patterns/sources/git.md`.
+
+## Related repos
+
+- `hiivmind/hiivmind-corpus` — the corpus plugin containing the headless refresh skill
+  and all pattern documentation referenced by the template
+- `hiivmind/hiivmind-corpus-{name}` — individual corpus repositories that these tasks
+  refresh
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A
+git commit -m "chore: drop per-task pyprojects (PEP 723 scripts) and document template model in CLAUDE.md
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Finish the scheduler branch — final verification, push, PR
+
+**Files:** none new.
+
+- [ ] **Step 1: Acceptance checks (backlog 05)**
+
+```bash
+cd /Users/nathanielramm/git/hiivmind/hiivmind-corpus-scheduler
+# a process change edits exactly one file:
+ls TEMPLATE-corpus-refresh.md
+# adding a corpus is a single stub:
+wc -l corpus-refresh-*/SKILL.md          # expected: ~26 lines each, identical counts
+# no per-task pyprojects remain outside archive/:
+find . -name pyproject.toml -not -path './.git/*' -not -path './archive/*'   # expected: empty
+# hygiene present:
+grep -n "superseded_prs\|pr_age_days" TEMPLATE-corpus-refresh.md   # expected: hits
+```
+
+- [ ] **Step 2: Push and create PR**
+
+```bash
+git push -u origin feature/wave3-consolidate-template
+gh pr create --title "refactor: consolidate seven tasks into shared template + stubs, add PR hygiene" --body "$(cat <<'EOF'
+Implements backlog item 05 (scheduler consolidation) from hiivmind-corpus docs/backlog/05-scheduler-consolidation.md.
+
+- All phases live in TEMPLATE-corpus-refresh.md; the seven tasks are now 3-constant stubs (directory names unchanged, so existing symlinks/schedules keep working)
+- Branch/PR hygiene: superseded automated/* PRs are closed (with comment + branch delete) after the new PR lands; unmerged-PR age reported in <run-summary>
+- Sparse-checkout/compare-API guidance upstreamed to the plugin's patterns/sources/git.md (companion PR in hiivmind-corpus); template keeps a pointer
+- Per-task pyprojects deleted (plugin scripts are PEP 723 self-contained since hiivmind-corpus PR #47)
+- CLAUDE.md updated: add-a-corpus = one stub; process change = edit the template only
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Report both PR URLs and stop**
+
+After both PRs are open, report: plugin PR (git.md), scheduler PR (consolidation), and the note that backlog 05 flips to Done after both merge. Do not merge; the user merges.
+
+---
+
+## Post-merge follow-up (not part of this plan's branches)
+
+- After both PRs merge: update `docs/backlog/index.md` item 05 → `Done (PR #N)` on plugin main.
+- No symlink changes needed on the host — directory names were preserved.

--- a/docs/superpowers/plans/2026-07-09-wave4-decision-capture-headless-surfaces.md
+++ b/docs/superpowers/plans/2026-07-09-wave4-decision-capture-headless-surfaces.md
@@ -1,0 +1,489 @@
+# Wave 4: Decision Capture + Headless Surfaces Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist every interactive build decision in a `build:` config block so headless skills can replay them; add contract-emitting headless surfaces for status and graph validation; and surface cumulative embedding drift (`embeddings_lag`) in status output and refresh PRs.
+
+**Architecture:** Principle: **interactive skills capture decisions; headless skills replay them.** The existing (informal) `config.build.verify_on_build` / `verify_sample_size` keys grow into a documented `build:` block covering all Phase 3/4 answers. Two thin headless skills reuse the wave-1 result-file contract (`kind: status`, `kind: graph-validate`). `embeddings_lag` is computed by comparing entry `last_indexed` timestamps against the Lance `_meta` embed timestamp via a tiny read-only script.
+
+**Tech Stack:** Markdown skills/patterns; Python tail: `lance_meta.py` (new, PEP 723), `validate_result.py` (two new kinds).
+
+## Global Constraints
+
+- Repo: `/Users/nathanielramm/git/hiivmind/hiivmind-corpus`, branch `feature/wave4-decision-capture` off up-to-date main. **Prerequisite: wave 2 (backlog 03) is merged** — the `render:` block exists and segmentation persists there; this wave must not re-invent it. Depends conceptually on wave 1's contract (merged, PR #47).
+- Order: skills/pattern docs first, Python last (user feedback, wave 1). Tests light.
+- Contract stays `contract_version: 1`; new kinds are backward-compatible additions.
+- `build-headless` (backlog stretch goal) is deliberately OUT of scope — YAGNI until a re-build consumer exists. The `build:` block makes it *possible* later; that is enough for acceptance.
+- Scheduler repo change (optional pre-check wiring) is a single small edit to `TEMPLATE-corpus-refresh.md` (exists after wave 3) — own branch/PR in `/Users/nathanielramm/git/hiivmind/hiivmind-corpus-scheduler`.
+- Commits: conventional, ending `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`. PR bodies end with `🤖 Generated with [Claude Code](https://claude.com/claude-code)`.
+- Acceptance (backlog 06): an interactively built corpus records all build decisions in config.yaml; headless enrichment places new entries per recorded organization without prompting; `status` reports embedding lag; orchestrators can run status/validate across corpora with machine-readable results.
+
+---
+
+### Task 1: `build:` block schema + build skill writes it
+
+**Files:**
+- Modify: `lib/corpus/patterns/config-parsing.md` (new section documenting the block)
+- Modify: `templates/config.yaml.template` (commented example)
+- Modify: `skills/hiivmind-corpus-build/SKILL.md` (Phase 8 "Update config metadata", ~line 652; Phases 3/4/7/7c pointers)
+
+**Interfaces:**
+- Produces: `config.build.*` keys that Task 2 (replay) and any future build-headless read. Exact keys below are the contract.
+
+- [ ] **Step 1: Document the schema in config-parsing.md**
+
+Add a top-level section:
+
+````markdown
+## The `build:` Block (decision capture)
+
+**Principle: interactive skills capture decisions; headless skills replay
+them.** The build skill records every Phase 3/4 answer here at save time.
+Enhance, refresh, and enrich-headless read these instead of guessing (or
+re-asking). A future `build-headless` re-build becomes possible because this
+block is a complete replay script of the interactive session.
+
+```yaml
+build:
+  use_case: reference            # reference | learning | troubleshooting | mixed
+  organization: by-topic         # by-topic | by-source | mixed
+  segmentation: tiered           # single | tiered | by-source | by-section
+                                 # (section definitions live in render.sections)
+  source_priorities: [polars, polars-blog]   # ordered, multi-source only; omit if single
+  skip_sections: [changelog, internal]       # [] if none
+  embeddings: true               # user opted in during Phase 7
+  verify_on_build: true          # Phase 7c preference (pre-existing key, now documented)
+  verify_sample_size: 20         # pre-existing key, now documented
+  decided_at: "2026-07-09T00:00:00Z"
+```
+
+Notes: `sections:`, `chunking:`, and `extraction:` remain per-source config
+(indexing-depth answers already persist there). `render:` holds the section
+definitions (see wave 2). Absent block = legacy corpus: skills fall back to
+current heuristics and SHOULD write the block when the user next answers the
+questions interactively.
+````
+
+Add the same block, commented out, to `templates/config.yaml.template`.
+
+- [ ] **Step 2: Build skill writes the block**
+
+In build SKILL.md Phase 8 "Update config metadata", add step:
+
+```markdown
+5. Write the `build:` block (see patterns/config-parsing.md § build: block):
+   use_case, organization, segmentation, source_priorities (multi-source only),
+   skip_sections, embeddings (Phase 7 opt-in outcome), verify_on_build /
+   verify_sample_size (Phase 7c settings), decided_at = now(). Preserve any
+   existing keys the user set by hand.
+```
+
+In Phases 3 and 4, after each ASK, add the one-liner: `(Recorded in config.build at Phase 8 — see patterns/config-parsing.md.)` In Phase 7 (embeddings opt-in) note the outcome is recorded as `build.embeddings`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A && git commit -m "feat(build): capture all interactive decisions in config.build block
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Replay in enhance / refresh / enrich-headless
+
+**Files:**
+- Modify: `skills/hiivmind-corpus-enhance/SKILL.md`
+- Modify: `skills/hiivmind-corpus-refresh/SKILL.md` and `skills/hiivmind-corpus-refresh-headless/SKILL.md`
+- Modify: `skills/hiivmind-corpus-enrich-headless/SKILL.md`
+- Modify: `lib/corpus/patterns/index-updating.md` (A-rule reads replayed prefs)
+
+**Interfaces:**
+- Consumes: `config.build.organization`, `config.build.skip_sections`, `config.build.use_case` (Task 1).
+
+- [ ] **Step 1: index-updating.md — new-entry placement honors the block**
+
+In the v2 "A (added file)" rule, add:
+
+```markdown
+Before creating a placeholder entry for an added file, consult `config.build`:
+- `skip_sections`: if the file's path or section matches a skipped section,
+  do NOT create an entry — log it as intentionally excluded instead.
+- `organization`: assign `category` (and `section`, if tiered) consistent with
+  the recorded organization — `by-source` corpora group new entries under
+  their source's section; `by-topic` corpora place them by subject.
+Absent block → current behavior (best-effort category, main index).
+```
+
+- [ ] **Step 2: Skill-side awareness**
+
+- **enhance:** in the phase that decides where deepened entries go, replace the "infer organization from existing index" instruction with: read `config.build.organization` / `skip_sections` first; fall back to inference only when the block is absent. Never ask the user a question already answered by the block — display the replayed value instead (`"Using recorded organization: by-topic"`).
+- **refresh / refresh-headless:** in the Phase that applies index changes, add one line: `Placement of added entries follows config.build (see patterns/index-updating.md) — skip_sections exclusions are logged in the result file's errors[] as "excluded-by-config: {path}" (informational, not a failure).`
+- **enrich-headless:** in the concept-assignment/save phase, add: `Enriched entries keep their existing category/section; new placement decisions follow config.build.organization as documented in patterns/index-updating.md.`
+
+- [ ] **Step 3: Verify and commit**
+
+```bash
+grep -n "config.build\|build\." skills/hiivmind-corpus-enhance/SKILL.md skills/hiivmind-corpus-refresh/SKILL.md skills/hiivmind-corpus-refresh-headless/SKILL.md skills/hiivmind-corpus-enrich-headless/SKILL.md lib/corpus/patterns/index-updating.md | grep -i "organization\|skip_sections"
+git add -A && git commit -m "feat(replay): enhance/refresh/enrich honor recorded build decisions
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `hiivmind-corpus-status-headless` skill
+
+**Files:**
+- Create: `skills/hiivmind-corpus-status-headless/SKILL.md`
+- Modify: `lib/corpus/patterns/headless-contract.md` (status-result.yaml schema)
+
+**Interfaces:**
+- Consumes: existing status skill's freshness checks (`patterns/status.md`, `patterns/freshness.md`); `lance_meta.py` (Task 6 — the skill references it; script lands in the Python tail of this same branch).
+- Produces: `{corpus_root}/status-result.yaml`, `kind: status`. The scheduler pre-check (Task 7) consumes `refresh_needed`.
+
+- [ ] **Step 1: Write the skill**
+
+`skills/hiivmind-corpus-status-headless/SKILL.md`, full content:
+
+````markdown
+---
+name: hiivmind-corpus-status-headless
+description: >
+  Non-interactive corpus freshness check for pipelines. Compares upstream SHAs
+  against config.yaml, counts stale entries and embedding lag, and writes
+  status-result.yaml (headless contract). Cheap: no clones, no index edits.
+  Triggers: "headless status", "status result file", scheduler pre-checks.
+---
+
+# Corpus Status (Headless)
+
+Read-only freshness snapshot of ONE corpus, written as a machine-readable
+result file. Designed as a cheap pre-check before a full refresh (ls-remote,
+not clone) and for nightly status sweeps across corpora.
+
+**Inputs:**
+- `corpus_path` (required)
+- `result_path` (optional, default `{corpus_path}/status-result.yaml`)
+
+## Phases
+
+1. **Validate:** read `{corpus_path}/config.yaml`; ABORT if missing. Detect
+   index format (index.yaml → v2, index.md only → v1, neither → unbuilt).
+2. **Source freshness (no clones, no fetches into .source/):** per source —
+   git/generated-docs/self: `git ls-remote <repo_url> refs/heads/<branch>`
+   (or local `git log -1` for self) vs `last_commit_sha` → `current | behind |
+   unknown`; local: newest mtime under `uploads/{id}/` vs `last_indexed_at`;
+   web: `current` if cache exists (manual refresh semantics); llms-txt:
+   manifest hash comparison per `patterns/sources/llms-txt.md`.
+3. **Index staleness:** v2 → `yq '[.entries[] | select(.stale == true)] |
+   length' index.yaml`; v1 → count `⏳ STALE` markers in index*.md.
+4. **Embedding lag:** if `index-embeddings.lance/` exists, run
+   `uv run ${CLAUDE_PLUGIN_ROOT}/lib/corpus/scripts/lance_meta.py index-embeddings.lance/`
+   to get `embedded_at`, then count entries whose `last_indexed` postdates it
+   (see patterns/embeddings.md § Embedding Lag). No lance dir → `null`.
+5. **Write result** (contract below), echo a one-line summary. Never modify
+   the corpus. Write the result file even on ABORT, with `error` populated.
+
+## Output Contract
+
+```yaml
+contract_version: 1
+kind: status
+corpus: {name}
+run_at: {ISO 8601}
+index_format: v2 | v1 | none
+sources:
+  - id: {source id}
+    type: {source type}
+    freshness: current | behind | unknown
+stale_entries: {int}             # entries flagged stale in the index
+embeddings_lag: {int|null}       # entries indexed after last embed; null = no embeddings
+refresh_needed: {bool}           # any source behind OR stale_entries > 0
+errors: []
+```
+
+Validate: `uv run ${CLAUDE_PLUGIN_ROOT}/lib/corpus/scripts/validate_result.py {result_path} --kind status`
+Ensure `status-result.yaml` is in the corpus .gitignore.
+
+## Reference
+
+- Patterns: `status.md`, `freshness.md`, `config-parsing.md`, `embeddings.md`, `headless-contract.md`
+- Related skills: hiivmind-corpus-status (interactive), hiivmind-corpus-refresh-headless, hiivmind-corpus-enrich-headless, hiivmind-corpus-migrate, hiivmind-corpus-discover, hiivmind-corpus-navigate, hiivmind-corpus-build, hiivmind-corpus-refresh, hiivmind-corpus-enhance, hiivmind-corpus-graph, hiivmind-corpus-bridge, hiivmind-corpus-init, hiivmind-corpus-add-source, hiivmind-corpus-register
+````
+
+- [ ] **Step 2: headless-contract.md**
+
+Add the file-locations row (`hiivmind-corpus-status-headless | status-result.yaml | {corpus_root}/status-result.yaml`), the `### status-result.yaml` schema section (YAML above with required/optional annotations: `index_format` enum required; `sources[].freshness` enum required; `stale_entries` int required; `embeddings_lag` int-or-null required; `refresh_needed` bool required), and `--kind status` in the validation examples.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A && git commit -m "feat(status): headless status skill emitting status-result.yaml
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Headless mode for graph validation
+
+**Files:**
+- Modify: `skills/hiivmind-corpus-graph/SKILL.md` (validate subcommand, ~lines 69-78)
+- Modify: `lib/corpus/patterns/headless-contract.md` (graph-validate-result.yaml schema)
+
+**Interfaces:**
+- Produces: `{corpus_root}/graph-validate-result.yaml`, `kind: graph-validate`. Intended as a PR check on corpus repos.
+
+- [ ] **Step 1: Extend the validate subcommand**
+
+After the existing `### validate` procedure, add:
+
+````markdown
+**Headless mode** (`validate --headless`, or `headless: true` input): run the
+same validation rules non-interactively and write
+`{corpus_path}/graph-validate-result.yaml`:
+
+```yaml
+contract_version: 1
+kind: graph-validate
+corpus: {name}
+run_at: {ISO 8601}
+concepts: {int}
+relationships: {int}
+issues:
+  - severity: error | warning
+    rule: {rule id from patterns/graph.md § Validation Rules}
+    detail: "{human-readable description with the offending id}"
+valid: {bool}                    # true when zero error-severity issues
+errors: []                       # runtime failures, not validation findings
+```
+
+Exit semantics for pipelines: emit the file always; `valid: false` when any
+error-severity issue exists. Validate the file with
+`uv run ${CLAUDE_PLUGIN_ROOT}/lib/corpus/scripts/validate_result.py graph-validate-result.yaml --kind graph-validate`.
+Ensure the filename is gitignored in the corpus. Note: rule 2 of the
+interactive procedure loads `index.md`; headless mode loads `index.yaml` when
+present (v2) since entry IDs are the join key being checked.
+````
+
+- [ ] **Step 2: headless-contract.md**
+
+Add the locations-table row, the `### graph-validate-result.yaml` schema section (YAML above), and the `--kind graph-validate` example.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A && git commit -m "feat(graph): headless validate writing graph-validate-result.yaml
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: `embeddings_lag` in interactive status, refresh result, and docs wiring
+
+**Files:**
+- Modify: `skills/hiivmind-corpus-status/SKILL.md` (§ Embeddings, ~line 190)
+- Modify: `skills/hiivmind-corpus-refresh-headless/SKILL.md` (Output Contract: optional field)
+- Modify: `lib/corpus/patterns/embeddings.md` (new § Embedding Lag)
+- Modify: `lib/corpus/patterns/headless-contract.md` (optional `embeddings_lag` on refresh-result)
+- Modify: `CLAUDE.md` and `commands/hiivmind-corpus.md` (alignment sweep for the two new skills + lag)
+- Modify: every existing skill's Reference list (add status-headless)
+
+**Interfaces:**
+- Consumes: `lance_meta.py` CLI (Task 6): `uv run …/lance_meta.py <lance_dir>` → JSON `{"embedded_at": "...", "model": "...", "row_count": N}` on stdout, exit 2 if no `_meta` table.
+
+- [ ] **Step 1: patterns/embeddings.md — define the metric once**
+
+```markdown
+## Embedding Lag
+
+`embeddings_lag` = number of index.yaml entries whose `last_indexed` postdates
+the Lance `_meta.embedded_at` timestamp. It measures cumulative drift between
+the index and its embeddings across runs (per-run status like
+`embeddings: skipped | no-model | deferred` cannot see accumulation).
+
+Compute:
+1. `uv run ${CLAUDE_PLUGIN_ROOT}/lib/corpus/scripts/lance_meta.py index-embeddings.lance/`
+   → `embedded_at` (exit 2 → no embeddings → lag is null)
+2. `EMB_AT={embedded_at} yq '[.entries[] | select(.last_indexed > env(EMB_AT))] | length' index.yaml`
+
+Lag > 0 with no pending stale entries means embeddings should be regenerated
+(enhance or enrich-headless re-embed paths). Reported by: status (interactive),
+status-headless (result file), refresh-headless (optional result field →
+scheduler PR body).
+```
+
+- [ ] **Step 2: Skill wiring**
+
+- **status SKILL.md § Embeddings:** add `Embedding lag: {n} entries indexed since last embed` line to the report, computed per patterns/embeddings.md § Embedding Lag (null → "no embeddings").
+- **refresh-headless Output Contract:** add optional `embeddings_lag: {int|null}` field after `embeddings:`, computed the same way post-Phase-5 (null when no lance dir).
+- **headless-contract.md refresh-result schema:** add `embeddings_lag` as optional int-or-null with the comment `# cumulative drift; see patterns/embeddings.md § Embedding Lag`.
+
+- [ ] **Step 3: CLAUDE.md / gateway alignment sweep**
+
+- Architecture tree, naming list, lifecycle "Headless pipeline" line: add `status-headless`; graph skill line mentions headless validate.
+- Cross-cutting table: extend "Headless result contract" row's skill list with status-headless and graph; add row `Decision capture | build, enhance, refresh, refresh-headless, enrich-headless | config.build block — patterns/config-parsing.md`; extend Embeddings row with `embeddings_lag`.
+- Dependency chain: add `status-headless ──► status-result.yaml` and `graph --headless ──► graph-validate-result.yaml`.
+- `commands/hiivmind-corpus.md`: add status-headless row (pipeline-facing).
+- Add `hiivmind-corpus-status-headless` to every skill's Reference section.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A && git commit -m "feat(status): embeddings_lag metric; alignment sweep for headless surfaces
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6 (Python tail): `lance_meta.py`, validator kinds, tests, PR
+
+**Files:**
+- Create: `lib/corpus/scripts/lance_meta.py`
+- Modify: `lib/corpus/scripts/validate_result.py` (kinds `status`, `graph-validate`; optional `embeddings_lag` on refresh)
+- Modify: `lib/corpus/scripts/tests/test_validate_result.py` (two tests)
+- Modify: `.github/workflows/ci.yml` (smoke line), `docs/backlog/index.md` (06 → In progress)
+
+**Interfaces:**
+- Consumes: `META_TABLE` from `lib/corpus/scripts/constants.py`; existing `validate(data, kind)` / `_require()` internals.
+- Produces: the exact CLI contract Task 5 documented.
+
+- [ ] **Step 1: lance_meta.py**
+
+```python
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["lancedb>=0.20.0", "pyarrow>=15.0.0"]
+# ///
+"""Print the _meta table of a Lance embeddings dir as JSON.
+
+Usage: lance_meta.py <lance_dir>
+Exit codes: 0 ok, 1 usage/open error, 2 no _meta table.
+"""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from constants import META_TABLE
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: lance_meta.py <lance_dir>", file=sys.stderr)
+        return 1
+    import lancedb
+
+    try:
+        db = lancedb.connect(sys.argv[1])
+        names = db.table_names()
+    except Exception as exc:  # unreadable / not a lance dir
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    if META_TABLE not in names:
+        print("error: no _meta table", file=sys.stderr)
+        return 2
+    row = db.open_table(META_TABLE).to_pandas().iloc[0].to_dict()
+    row = {k: (v.isoformat() if hasattr(v, "isoformat") else v) for k, v in row.items()}
+    print(json.dumps(row))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+Check `embed.py` for the actual `_meta` column names before finishing — if the timestamp column is named differently than `embedded_at`, emit it as-is (the JSON passes all columns through) and align the docs in Task 5 Step 1 to the real name.
+
+Smoke: `uv run lib/corpus/scripts/lance_meta.py /Users/nathanielramm/git/hiivmind/hiivmind-corpus-lancedb/index-embeddings.lance/` → JSON on stdout, exit 0.
+
+- [ ] **Step 2: validate_result.py kinds**
+
+- `--kind` choices += `status`, `graph-validate`.
+- `_validate_status`: `index_format` in `{v2, v1, none}`; `sources` list (each: `id` str, `type` str, `freshness` in `{current, behind, unknown}`); `stale_entries` int; `embeddings_lag` int or None (key required, value nullable); `refresh_needed` bool.
+- `_validate_graph_validate`: `concepts` int; `relationships` int; `issues` list (each: `severity` in `{error, warning}`, `rule` str, `detail` str); `valid` bool.
+- refresh kind: accept optional `embeddings_lag` (int or None) — no error when absent.
+
+- [ ] **Step 3: Tests + suite + smoke + PR**
+
+Add `test_valid_status_result` and `test_valid_graph_validate_result` to `test_validate_result.py` (mirror the existing valid-refresh test using the YAML blocks from Tasks 3/4). Append to the CI smoke step: `uv run lib/corpus/scripts/lance_meta.py --help 2>/dev/null || true` is NOT useful (no --help); instead add `uv run lib/corpus/scripts/validate_result.py --help` already covers the validator — add nothing for lance_meta (it needs a real lance dir; local smoke in Step 1 suffices).
+
+```bash
+uv run --group dev pytest -q -m "not model"    # expected: all pass
+```
+
+Set backlog 06 → `In progress (wave 4)`. Commit, push, PR:
+
+```bash
+git add -A && git commit -m "feat(contract): status + graph-validate kinds; lance_meta.py for embedding lag
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+git push -u origin feature/wave4-decision-capture
+gh pr create --title "feat: decision capture in config.build + headless status/graph surfaces (backlog 06)" --body "$(cat <<'EOF'
+Implements backlog item 06 (docs/backlog/06-decision-capture-and-headless-surfaces.md).
+
+- build: block records every interactive decision (use_case, organization, segmentation, priorities, skip_sections, embeddings opt-in, verify prefs); enhance/refresh/enrich replay instead of guessing
+- New hiivmind-corpus-status-headless: cheap ls-remote freshness snapshot → status-result.yaml (kind: status); scheduler can pre-check before a full refresh
+- graph validate --headless → graph-validate-result.yaml (kind: graph-validate), usable as a corpus-repo PR check
+- embeddings_lag drift metric (lance_meta.py + yq) in status output, status-result, and optionally refresh-result
+- build-headless deliberately deferred (stretch); the block makes it possible later
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+### Task 7: Scheduler pre-check wiring (separate repo, AFTER Task 6's PR merges and the plugin updates)
+
+**Files:**
+- Modify: `/Users/nathanielramm/git/hiivmind/hiivmind-corpus-scheduler/TEMPLATE-corpus-refresh.md` (Phase 3 head; exists after wave 3)
+
+**Interfaces:**
+- Consumes: `status-result.yaml` → `refresh_needed` (Task 3).
+
+- [ ] **Step 1: Branch and add the optional pre-check**
+
+```bash
+cd /Users/nathanielramm/git/hiivmind/hiivmind-corpus-scheduler
+git checkout main && git pull && git checkout -b feature/status-precheck
+```
+
+At the top of Phase 3 in `TEMPLATE-corpus-refresh.md`, before the CALL_SKILL of refresh-headless, insert:
+
+````markdown
+**Pre-check (cheap):** run the headless status skill first —
+
+```
+CALL_SKILL("hiivmind-corpus:hiivmind-corpus-status-headless", { corpus_path: computed.corpus_path })
+```
+
+Read `{corpus_path}/status-result.yaml` (validate with
+`uv run ${CLAUDE_PLUGIN_ROOT}/lib/corpus/scripts/validate_result.py ... --kind status`).
+If `refresh_needed: false` AND `embeddings_lag` in (0, null): skip the refresh
+entirely — clean up the branch (`git checkout main && git branch -d {branch}`),
+report "already current (pre-check)" in the summary, and go to SUMMARY. If the
+pre-check itself fails, log it and proceed with the full refresh — the
+pre-check is an optimization, never a gate.
+````
+
+Also add `embeddings_lag` to the PR-body instruction in Phase 4: `report embeddings_lag from refresh-result.yaml when present and > 0 ("N entries await re-embedding").`
+
+- [ ] **Step 2: Commit, push, PR**
+
+```bash
+git add TEMPLATE-corpus-refresh.md
+git commit -m "feat: cheap status-headless pre-check before full refresh; report embeddings_lag
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+git push -u origin feature/status-precheck
+gh pr create --title "feat: status-headless pre-check + embeddings_lag in PR body" --body "Wires backlog 06's status-headless as an optional pre-check: skip the full refresh when nothing changed upstream and no drift exists. Pre-check failure never blocks a refresh.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+After both PRs merge: flip backlog 06 → Done in `docs/backlog/index.md`.


### PR DESCRIPTION
Adds the wave 2, 3, and 4 implementation plans to docs/superpowers/plans/ alongside the already-committed wave 1 plan.

These were written as untracked files and were never committed; a main sync auto-stashed them (untracked files travel with the stash on checkout) and they were subsequently parked in a scratchpad during wave 2 implementation. Checking them in makes them permanent.

- Wave 2 (tiered v2 rendering, migrate skill, v1 read-only) — implemented, merged in #49
- Wave 3 (scheduler consolidation) — implemented, merged (#48 + scheduler #1)
- Wave 4 (decision capture + more headless surfaces) — not yet implemented

🤖 Generated with [Claude Code](https://claude.com/claude-code)