### PR TITLE
fix(render): portable title-casing + empty-TSV column shift in render-index.sh

### DIFF
--- a/templates/render-index.sh
+++ b/templates/render-index.sh
@@ -52,7 +52,8 @@ render_entries() {
 
   for CAT in $categories; do
     echo ""
-    CAT_HEADING=$(echo "$CAT" | sed 's/\b\(.\)/\u\1/g')
+    # Title-case each word. Portable (BSD/macOS sed lacks GNU \u).
+    CAT_HEADING=$(echo "$CAT" | awk '{for(i=1;i<=NF;i++)$i=toupper(substr($i,1,1)) substr($i,2)}1')
     echo "## ${CAT_HEADING}"
     echo ""
     MODE="$mode" SECTION="$section" VALID="$VALID_SECTIONS" CAT_FILTER="$CAT" yq -r '
@@ -68,11 +69,13 @@ render_entries() {
         ))
       | sort_by(.title)
       | .[]
-      | [.title, .id, .summary, .size, (.grep_hint // ""), (.stale | tostring)]
+      | [.title, .id, .summary, .size, (.grep_hint // "~"), (.stale | tostring)]
       | @tsv
     ' "$INDEX_YAML" | while IFS=$'\t' read -r title id summary size grep_hint stale; do
+      # Tab is IFS-whitespace, so an empty field would be collapsed and shift the
+      # columns; a "~" sentinel keeps grep_hint non-empty ("~" = no hint).
       line="- **${title}** \`${id}\` - ${summary}"
-      if [[ "$size" == "large" && -n "$grep_hint" ]]; then
+      if [[ "$size" == "large" && -n "$grep_hint" && "$grep_hint" != "~" ]]; then
         line+=" ⚡ GREP - \`${grep_hint}\`"
       fi
       if [[ "$stale" == "true" ]]; then


### PR DESCRIPTION
Two cross-platform bugs in `templates/render-index.sh`, both surfaced while migrating the Fly.io corpus to v2:

1. **Lowercase category headings on macOS.** The category `## ` headings were title-cased with GNU sed's `\u`, which is a silent no-op on BSD/macOS sed — producing `## api` instead of `## Api`. Replaced with a portable `awk` title-caser. (CI on Linux/GNU sed rendered correctly, so this only bit local renders.)

2. **Spurious `⚡ GREP - \`false\`` on every large entry.** `read` uses `IFS=$'\t'`, and tab is IFS-whitespace, so an *empty* `grep_hint` field was collapsed and shifted the `stale` value (`false`) into the `grep_hint` column. Now a `"~"` sentinel is emitted for null `grep_hint` (treated as "no hint" in bash), so the column never collapses.

No behavior change for corpora whose large entries have real grep hints; fixes rendering for the common null-hint case and for non-GNU `sed`.

Discovered by: hiivmind-corpus-flyio#5 (v1→v2 migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)