### PR TITLE
feat: hiivmind-corpus-build-headless (replay config.build for non-interactive rebuild)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ The core value: Persistent human-curated indexes that track upstream changes, in
 │   ├── hiivmind-corpus-build/        # Analyze docs, build index with user
 │   ├── hiivmind-corpus-enhance/      # Deepen coverage on specific topics
 │   ├── hiivmind-corpus-refresh/      # Refresh index from upstream changes
+│   ├── hiivmind-corpus-build-headless/   # Non-interactive rebuild replaying config.build
 │   ├── hiivmind-corpus-refresh-headless/ # Non-interactive refresh for pipelines
 │   ├── hiivmind-corpus-enrich-headless/  # Non-interactive stale-entry enrichment
 │   ├── hiivmind-corpus-migrate/      # One-shot v1→v2 index migration (headless)
@@ -144,6 +145,7 @@ Migration (one-shot): hiivmind-corpus-migrate  (v1 index.md → v2 index.yaml + 
 6. **hiivmind-corpus-refresh-headless**: Non-interactive refresh for automated pipelines; writes `refresh-result.yaml`
 7. **hiivmind-corpus-enrich-headless**: Non-interactive enrichment of stale entries (re-scan, concept assignment, verification, re-embed); writes `enrich-result.yaml`
 8. **hiivmind-corpus-migrate**: One-shot headless v1→v2 migration (parse index.md/index-*.md → index.yaml + `render:` block, deterministic render, ID-parity diff-check); writes `migrate-result.yaml`
+9. **hiivmind-corpus-build-headless**: Non-interactive (re)build replaying `config.build` decisions (scan → index → optional graph/embeddings → verify); writes `build-result.yaml`
 
 **Discovery & Navigation Skills:**
 6. **hiivmind-corpus-discover**: Scans for installed corpora
@@ -189,9 +191,9 @@ hiivmind-corpus-{project}/
 
 All components follow the `hiivmind-corpus-*` naming pattern:
 - Meta-plugin: `hiivmind-corpus`
-- Build skills: `hiivmind-corpus-init`, `hiivmind-corpus-add-source`, `hiivmind-corpus-build`, `hiivmind-corpus-enhance`, `hiivmind-corpus-refresh`, `hiivmind-corpus-refresh-headless`, `hiivmind-corpus-enrich-headless`, `hiivmind-corpus-migrate`
+- Build skills: `hiivmind-corpus-init`, `hiivmind-corpus-add-source`, `hiivmind-corpus-build`, `hiivmind-corpus-build-headless`, `hiivmind-corpus-enhance`, `hiivmind-corpus-refresh`, `hiivmind-corpus-refresh-headless`, `hiivmind-corpus-enrich-headless`, `hiivmind-corpus-migrate`
 - Read skills: `hiivmind-corpus-discover`, `hiivmind-corpus-navigate`, `hiivmind-corpus-register`, `hiivmind-corpus-status`, `hiivmind-corpus-status-headless`, `hiivmind-corpus-graph`, `hiivmind-corpus-bridge`
-- Headless skills: `hiivmind-corpus-refresh-headless`, `hiivmind-corpus-enrich-headless`, `hiivmind-corpus-migrate`, `hiivmind-corpus-status-headless`, `hiivmind-corpus-graph` (`--headless`)
+- Headless skills: `hiivmind-corpus-build-headless`, `hiivmind-corpus-refresh-headless`, `hiivmind-corpus-enrich-headless`, `hiivmind-corpus-migrate`, `hiivmind-corpus-status-headless`, `hiivmind-corpus-graph` (`--headless`)
 - Gateway command: `/hiivmind-corpus`
 - Generated corpora: `hiivmind-corpus-{project}` (e.g., `hiivmind-corpus-flyio`, `hiivmind-corpus-polars`)
 
@@ -323,9 +325,9 @@ These features span multiple skills and must stay synchronized:
 | Structure-aware chunking | build, source-scanner, navigate | `headings` strategy in `chunk.py`, `heading_context` in embeddings |
 | Index updating | refresh, refresh-headless, enrich-headless | Single algorithm in `patterns/index-updating.md` — never duplicate into skills; v1 write paths are read-only (migrate to v2) |
 | v1→v2 migration | migrate, refresh, refresh-headless, enhance | v1 read-only gating routes to `hiivmind-corpus-migrate`; render: block + section field; migrate-result contract |
-| Headless result contract | refresh-headless, enrich-headless, migrate, status-headless, graph, scheduler tasks | `contract_version`, result files (refresh/enrich/migrate/status/graph-validate), `validate_result.py` |
+| Headless result contract | refresh-headless, enrich-headless, migrate, status-headless, build-headless, graph, scheduler tasks | `contract_version`, result files (refresh/enrich/migrate/status/graph-validate/build), `validate_result.py` |
 | Headless enrichment | refresh-headless, enrich-headless, graph, build | Stale-entry resolution, concept assignment from existing graph only, result contract |
-| Decision capture | build, enhance, refresh, refresh-headless, enrich-headless | `config.build` block records interactive decisions; headless skills replay instead of guessing — `patterns/config-parsing.md` § The `build:` Block |
+| Decision capture | build, build-headless, enhance, refresh, refresh-headless, enrich-headless | `config.build` block records interactive decisions; build-headless and the headless refresh/enrich skills replay instead of guessing — `patterns/config-parsing.md` § The `build:` Block |
 
 ### When Adding New Features
 
@@ -375,9 +377,10 @@ enrich-headless ──► source-scanner agent, verify_entries.py, index-embeddi
 migrate ──► index.yaml + config.yaml render: block + render-index.sh (one-shot v1→v2), migrate-result.yaml
 status-headless ──► lance_meta.py, status-result.yaml (cheap ls-remote pre-check; scheduler reads refresh_needed)
 graph --headless ──► graph-validate-result.yaml (corpus-repo PR check)
-build ──► config.build block (decision capture); enhance/refresh/enrich-headless ◄── config.build (replay)
+build ──► config.build block (decision capture); build-headless/enhance/refresh/enrich-headless ◄── config.build (replay)
+build-headless ──► source-scanner agent, index.yaml, optional graph.yaml/embeddings, build-result.yaml (headless rebuild)
 status/status-headless/refresh-headless ──► lance_meta.py ──► embeddings_lag (drift metric)
-build/refresh/migrate ──► render-index.sh ──► index.md (+ index-{section}.md when tiered)
+build/build-headless/refresh/migrate ──► render-index.sh ──► index.md (+ index-{section}.md when tiered)
 ```
 
 ### Reference Sections

--- a/commands/hiivmind-corpus.md
+++ b/commands/hiivmind-corpus.md
@@ -123,3 +123,4 @@ Skill(
 | `hiivmind-corpus-enrich-headless` | Pipeline-facing stale-entry enrichment (automation; users normally want `enhance` or `refresh`) |
 | `hiivmind-corpus-migrate` | One-shot v1→v2 index migration (headless) |
 | `hiivmind-corpus-status-headless` | Pipeline-facing freshness snapshot → `status-result.yaml` (automation; users normally want `status`) |
+| `hiivmind-corpus-build-headless` | Pipeline-facing rebuild replaying `config.build` → `build-result.yaml` (automation; users normally want `build`) |

--- a/lib/corpus/patterns/config-parsing.md
+++ b/lib/corpus/patterns/config-parsing.md
@@ -220,8 +220,9 @@ does not lose data — its entries just fall back to the main index on next rend
 **Principle: interactive skills capture decisions; headless skills replay
 them.** The build skill records every Phase 3/4 answer here at save time.
 Enhance, refresh, and enrich-headless read these instead of guessing (or
-re-asking). A future `build-headless` re-build becomes possible because this
-block is a complete replay script of the interactive session.
+re-asking), and `hiivmind-corpus-build-headless` replays the whole block to
+reconstruct the index non-interactively — this block is a complete replay
+script of the interactive session.
 
 ```yaml
 build:

--- a/lib/corpus/patterns/headless-contract.md
+++ b/lib/corpus/patterns/headless-contract.md
@@ -13,6 +13,7 @@ retained for human-readable logs only — orchestrators MUST read the file.
 | hiivmind-corpus-migrate | migrate-result.yaml | `{corpus_root}/migrate-result.yaml` |
 | hiivmind-corpus-status-headless | status-result.yaml | `{corpus_root}/status-result.yaml` |
 | hiivmind-corpus-graph (--headless) | graph-validate-result.yaml | `{corpus_root}/graph-validate-result.yaml` |
+| hiivmind-corpus-build-headless | build-result.yaml | `{corpus_root}/build-result.yaml` |
 
 Result files are transient run artifacts: the skill ensures both filenames are
 listed in the corpus `.gitignore` (appending if missing) before writing.
@@ -34,6 +35,7 @@ not asked to validate.
     uv run ${CLAUDE_PLUGIN_ROOT}/lib/corpus/scripts/validate_result.py migrate-result.yaml --kind migrate
     uv run ${CLAUDE_PLUGIN_ROOT}/lib/corpus/scripts/validate_result.py status-result.yaml --kind status
     uv run ${CLAUDE_PLUGIN_ROOT}/lib/corpus/scripts/validate_result.py graph-validate-result.yaml --kind graph-validate
+    uv run ${CLAUDE_PLUGIN_ROOT}/lib/corpus/scripts/validate_result.py build-result.yaml --kind build
 
 Orchestrators should validate before consuming and treat exit 1/2 as a failed
 run (report, do not commit). Exit codes: 0 valid, 1 invalid (errors on
@@ -137,6 +139,29 @@ issues:                               # required list (may be empty)
     detail: <str>                     # required — human-readable, includes offending id
 valid: <bool>                         # required — true when zero error-severity issues
 errors: [<str>, ...]                  # required — runtime failures, not findings
+```
+
+### build-result.yaml (written by hiivmind-corpus-build-headless)
+
+```yaml
+contract_version: 1
+kind: build
+corpus: <name>                        # str, required
+run_at: <ISO 8601>                    # str, required
+entries: <int>                        # required — index.meta.entry_count
+sources:                              # required list (may be empty)
+  - id: <source id>                   # str, required
+    type: <source type>              # str, required
+    files_scanned: <int>             # required
+strategy: single | tiered             # required enum
+sections: [<str>, ...]                # required — section ids ([] when single)
+graph: generated | skipped | not-configured   # required enum
+embeddings: updated | skipped | no-model | not-installed   # required enum
+verification:                         # required
+  sampled: <int>
+  failed: <int>
+  drift_entries: [<entry id>, ...]
+errors: [<str>, ...]                  # required — includes excluded-by-config notes
 ```
 
 ## Source status semantics

--- a/lib/corpus/scripts/tests/test_validate_result.py
+++ b/lib/corpus/scripts/tests/test_validate_result.py
@@ -93,6 +93,28 @@ errors: []
 """
 
 
+VALID_BUILD = """\
+contract_version: 1
+kind: build
+corpus: lancedb
+run_at: "2026-07-10T00:00:00Z"
+entries: 193
+sources:
+  - id: lancedb-docs
+    type: git
+    files_scanned: 210
+strategy: tiered
+sections: ["guides", "api-reference"]
+graph: generated
+embeddings: updated
+verification:
+  sampled: 20
+  failed: 1
+  drift_entries: ["lancedb-docs:guides/drift.md"]
+errors: []
+"""
+
+
 def run_validate(tmp_path, content, kind):
     f = tmp_path / "result.yaml"
     f.write_text(content)
@@ -137,6 +159,18 @@ def test_refresh_optional_embeddings_lag_ok(tmp_path):
     content = VALID_REFRESH.replace("embeddings: deferred", "embeddings: deferred\nembeddings_lag: 5")
     r = run_validate(tmp_path, content, "refresh")
     assert r.returncode == 0, r.stderr
+
+
+def test_valid_build_result(tmp_path):
+    r = run_validate(tmp_path, VALID_BUILD, "build")
+    assert r.returncode == 0, r.stderr
+
+
+def test_build_invalid_graph_fails(tmp_path):
+    broken = VALID_BUILD.replace("graph: generated", "graph: banana")
+    r = run_validate(tmp_path, broken, "build")
+    assert r.returncode == 1
+    assert "graph" in r.stderr
 
 
 def test_invalid_result_fails(tmp_path):

--- a/lib/corpus/scripts/validate_result.py
+++ b/lib/corpus/scripts/validate_result.py
@@ -5,7 +5,7 @@
 # ///
 """Validate a headless result file against the corpus result contract.
 
-Usage: validate_result.py <result.yaml> --kind refresh|enrich|migrate|status|graph-validate
+Usage: validate_result.py <result.yaml> --kind refresh|enrich|migrate|status|graph-validate|build
 
 See lib/corpus/patterns/headless-contract.md for the schemas.
 
@@ -27,6 +27,9 @@ MIGRATE_SKIP_REASONS = {"file-missing", "clone-failed"}
 INDEX_FORMATS = {"v2", "v1", "none"}
 STATUS_FRESHNESS = {"current", "behind", "unknown"}
 GRAPH_SEVERITIES = {"error", "warning"}
+BUILD_STRATEGIES = {"single", "tiered"}
+BUILD_GRAPH = {"generated", "skipped", "not-configured"}
+BUILD_EMBEDDINGS = {"updated", "skipped", "no-model", "not-installed"}
 
 
 def _require_int_or_null(data, key, errors, ctx=""):
@@ -163,6 +166,35 @@ def validate(data: dict, kind: str) -> list[str]:
             _require(iss, "detail", str, errors, ctx=f"issues[{i}].")
         _require(data, "valid", bool, errors)
 
+    elif kind == "build":
+        _require(data, "entries", int, errors)
+        sources = _require(data, "sources", list, errors)
+        for i, s in enumerate(sources or []):
+            if not isinstance(s, dict):
+                _err(errors, f"sources[{i}] is not a mapping")
+                continue
+            _require(s, "id", str, errors, ctx=f"sources[{i}].")
+            _require(s, "type", str, errors, ctx=f"sources[{i}].")
+            _require(s, "files_scanned", int, errors, ctx=f"sources[{i}].")
+        strategy = _require(data, "strategy", str, errors)
+        if strategy is not None and strategy not in BUILD_STRATEGIES:
+            _err(errors, f"strategy invalid: {strategy}")
+        sections = _require(data, "sections", list, errors)
+        for i, sec in enumerate(sections or []):
+            if not isinstance(sec, str):
+                _err(errors, f"sections[{i}] is not a string")
+        graph = _require(data, "graph", str, errors)
+        if graph is not None and graph not in BUILD_GRAPH:
+            _err(errors, f"graph invalid: {graph}")
+        emb = _require(data, "embeddings", str, errors)
+        if emb is not None and emb not in BUILD_EMBEDDINGS:
+            _err(errors, f"embeddings invalid: {emb}")
+        ver = _require(data, "verification", dict, errors)
+        if ver is not None:
+            _require(ver, "sampled", int, errors, ctx="verification.")
+            _require(ver, "failed", int, errors, ctx="verification.")
+            _require(ver, "drift_entries", list, errors, ctx="verification.")
+
     return errors
 
 
@@ -170,7 +202,7 @@ def main():
     parser = argparse.ArgumentParser(description="Validate a headless result file")
     parser.add_argument("file", help="Path to result YAML file")
     parser.add_argument("--kind", required=True,
-                        choices=["refresh", "enrich", "migrate", "status", "graph-validate"])
+                        choices=["refresh", "enrich", "migrate", "status", "graph-validate", "build"])
     args = parser.parse_args()
 
     path = Path(args.file)

--- a/skills/hiivmind-corpus-add-source/SKILL.md
+++ b/skills/hiivmind-corpus-add-source/SKILL.md
@@ -324,6 +324,7 @@ Source-specific operations referenced by this skill:
 
 - Migrate v1→v2 (headless): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-migrate/SKILL.md`
 - Headless status (pipelines): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-status-headless/SKILL.md`
+- Headless rebuild (pipelines): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-build-headless/SKILL.md`
 - Initialize corpus: `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-init/SKILL.md`
 - Build full index: `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-build/SKILL.md`
 - Enhance topics: `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-enhance/SKILL.md`

--- a/skills/hiivmind-corpus-bridge/SKILL.md
+++ b/skills/hiivmind-corpus-bridge/SKILL.md
@@ -211,6 +211,7 @@ Manually add a query-routing alias.
 
 - Migrate v1→v2 (headless): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-migrate/SKILL.md`
 - Headless status (pipelines): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-status-headless/SKILL.md`
+- Headless rebuild (pipelines): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-build-headless/SKILL.md`
 - `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-graph/SKILL.md` — Per-corpus concept graph (view, validate, edit)
 - `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-navigate/SKILL.md` — Uses bridges for Tier 4 cross-corpus retrieval
 - `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-register/SKILL.md` — Registers corpora to project registry

--- a/skills/hiivmind-corpus-build-headless/SKILL.md
+++ b/skills/hiivmind-corpus-build-headless/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: hiivmind-corpus-build-headless
+description: >
+  Non-interactive (re)build of a corpus index for pipelines. Replays the
+  decisions captured in config.build (segmentation, organization, skip_sections,
+  embeddings, verify prefs) instead of prompting, regenerates index.yaml + the
+  rendered markdown, optional graph and embeddings, and writes build-result.yaml
+  (headless contract). Triggers: "headless build", "rebuild corpus headless",
+  "build result file", scheduled rebuilds. Users normally want `build`.
+allowed-tools: Read, Glob, Grep, Write, Edit, Bash, WebFetch, Task
+inputs:
+  - name: corpus_path
+    type: string
+    required: false
+    description: Absolute path to the corpus root (uses current working directory if not provided)
+  - name: result_path
+    type: string
+    required: false
+    description: Where to write build-result.yaml (defaults to {corpus_root}/build-result.yaml)
+---
+
+# Corpus Build (Headless)
+
+Non-interactive variant of `hiivmind-corpus-build`. Reconstructs `index.yaml`
+(and the rendered markdown, optional `graph.yaml`, optional embeddings) by
+**replaying** the decisions the interactive build captured in `config.build`.
+No prompts, no `AskUserQuestion` — every Phase 3/4/7 answer comes from config.
+
+**Principle: interactive skills capture decisions; headless skills replay them.**
+This skill is the replay counterpart of the interactive build's decision capture
+(see `${CLAUDE_PLUGIN_ROOT}/lib/corpus/patterns/config-parsing.md` § The `build:`
+Block). It follows the SAME phase pipeline as `hiivmind-corpus-build`; only the
+interactive prompts are replaced by config reads.
+
+**Inputs:**
+- `corpus_path` (optional; defaults to cwd)
+- `result_path` (optional; defaults to `{corpus_path}/build-result.yaml`)
+
+## State
+
+```yaml
+computed:
+  corpus_root: null
+  config: null
+  build: null              # config.build replay block (REQUIRED)
+  sources: []
+  scan_results: null
+  strategy: null           # single | tiered (from config.render)
+  index: null
+  entry_count: 0
+  graph_status: null       # generated | skipped | not-configured
+  embedding_status: null   # updated | skipped | no-model | not-installed
+  verification: null       # { sampled, failed, drift_entries }
+  errors: []
+  error: null              # fatal → ABORT
+```
+
+## Phase 1: Validate & Load Decisions
+
+Resolve corpus root from `corpus_path` or cwd. Read `config.yaml`
+(`${CLAUDE_PLUGIN_ROOT}/lib/corpus/patterns/config-parsing.md`). ABORT (write a
+result with `error` populated) if:
+
+- `config.yaml` missing, or `sources` is empty.
+- **`config.build` is absent.** Headless build has nothing to replay — the
+  decisions were never captured. Write `errors: ["no-build-block — run the
+  interactive hiivmind-corpus-build once to capture decisions"]` and ABORT.
+  (This is the deliberate gate: build-headless never *invents* organization.)
+
+Load `computed.build = config.build` and `computed.strategy = config.render.strategy // "single"`.
+
+## Phase 2: Prepare & Scan Sources
+
+Identical to `hiivmind-corpus-build` Phases 1–2 — reuse them, do not re-describe:
+- Prepare each source (clone/cache/verify) per its type; for git prefer the
+  sparse clone in `patterns/sources/git.md`.
+- Scan with parallel `source-scanner` agents (2+ sources) or inline (single).
+  Indexing depth (sections/chunking) comes from each source's persisted
+  `sections:`/`chunking:` config — no prompt.
+
+Record per-source `{id, type, files_scanned}` for the result.
+
+## Phase 3: Segmentation (replayed)
+
+No prompt. Use `computed.strategy` and, when `tiered`, the section definitions
+already in `config.render.sections`. "By source" corpora are tiered with one
+section per source id (as recorded during the interactive build).
+
+## Phase 4: Index Generation (replayed)
+
+Generate `index.yaml` exactly as build Phase 5, but drive organization from
+`computed.build` instead of asking:
+- **`skip_sections`:** files under a skipped section are NOT indexed — count them
+  into `errors[]` as `"excluded-by-config: {path}"` (informational).
+- **`organization`:** `by-source` → assign each entry `section = source.id`;
+  `by-topic` → assign `section`/`category` by subject; `mixed` → topic-first.
+- **`use_case` / `source_priorities`:** bias entry depth/ordering as the
+  interactive build would (higher-priority sources get richer entries).
+
+See `${CLAUDE_PLUGIN_ROOT}/lib/corpus/patterns/index-updating.md` § New-entry
+placement — the same placement rules the headless refresh uses.
+
+## Phase 5: Graph (optional, deterministic)
+
+Only if at least one source produced `extraction:` data (build Phase 6
+precondition). Non-interactive: **auto-accept** the clustered concepts (no
+rename/merge/discard prompt), generate relationships, write `graph.yaml`, and
+populate `concepts[]` on the matched index.yaml entries. Set
+`computed.graph_status = generated`. No extraction data → `not-configured`.
+Extraction present but clustering yields nothing → `skipped`.
+
+## Phase 6: Embeddings (optional, replayed)
+
+Replay `computed.build.embeddings`:
+- `false` → `computed.embedding_status = skipped`.
+- `true` → run `uv run ${CLAUDE_PLUGIN_ROOT}/lib/corpus/scripts/detect.py`:
+  - `ready` → `uv run ${CLAUDE_PLUGIN_ROOT}/lib/corpus/scripts/embed.py index.yaml index-embeddings.lance/` → `updated`.
+  - `no-model` → `no-model` (NEVER download a model during automation).
+  - not installed → `not-installed`.
+- If any source has `chunking.enabled`, also generate `chunks-embeddings.lance/`
+  per build Phase 7b (same detect gating).
+
+## Phase 7: Verification (replayed)
+
+Replay `computed.build.verify_on_build`:
+- `false` → `computed.verification = { sampled: 0, failed: 0, drift_entries: [] }`.
+- `true` → run `uv run ${CLAUDE_PLUGIN_ROOT}/lib/corpus/scripts/verify_entries.py
+  --index index.yaml --source-root .source/ --config config.yaml --sample
+  {config.build.verify_sample_size // 20}`, then LLM-verify the sampled previews.
+  Record `sampled`, `failed`, and the drifting entry ids in `drift_entries`.
+  **Do NOT prompt to regenerate** — headless only reports drift; a later
+  `enrich-headless`/`enhance` fixes it.
+
+## Phase 8: Save, Render, Result
+
+1. Write `index.yaml` (`meta.generated_at = now()`, `meta.entry_count`).
+2. Copy `${CLAUDE_PLUGIN_ROOT}/templates/render-index.sh` to the corpus root
+   (overwrite) and run `bash render-index.sh index.yaml` — with `tiered` this
+   emits every `index-{section}.md`. Never hand-write sub-indexes.
+3. Update config metadata: `index.last_updated_at = now()`, per-source
+   `last_indexed_at` (and `last_commit_sha` for git sources at clone HEAD).
+   Refresh `config.build.decided_at` is NOT changed — replay does not re-decide.
+4. Write the result file (contract below).
+
+## Output Contract
+
+**See:** `${CLAUDE_PLUGIN_ROOT}/lib/corpus/patterns/headless-contract.md`
+
+Ensure the corpus `.gitignore` lists `build-result.yaml` (append if missing),
+then write `result_path` (default `{corpus_root}/build-result.yaml`):
+
+```yaml
+contract_version: 1
+kind: build
+corpus: {name from config}
+run_at: {ISO 8601}
+entries: {int}                   # index.meta.entry_count
+sources:                         # one per scanned source
+  - id: {source id}
+    type: {source type}
+    files_scanned: {int}
+strategy: single | tiered
+sections: [{section ids}]        # [] when single
+graph: generated | skipped | not-configured
+embeddings: updated | skipped | no-model | not-installed
+verification:
+  sampled: {int}
+  failed: {int}
+  drift_entries: [{entry id}, ...]
+errors: [{description}, ...]      # includes excluded-by-config notes
+```
+
+Validate before finishing:
+`uv run ${CLAUDE_PLUGIN_ROOT}/lib/corpus/scripts/validate_result.py {result_path} --kind build`
+
+Write the result file even on ABORT (with `error`/`errors` populated). Echo the
+same YAML between `---headless-result` and `---` markers as a log convenience —
+pipelines MUST read the file.
+
+## Error Handling
+
+| Error | Handling |
+|-------|----------|
+| No config.yaml / no sources | ABORT with result `errors` populated |
+| No `config.build` block | ABORT: "no-build-block — run interactive build once" |
+| A source fails to prepare/scan | Mark that source failed in `errors[]`; continue with the rest |
+| detect.py unavailable / no-model | Skip embeddings (`no-model`/`not-installed`); never download |
+| render-index.sh missing | Copy it from the plugin templates before rendering |
+
+## Reference
+
+- Patterns: `config-parsing.md` (§ The `build:` Block), `index-format-v2.md`, `index-rendering.md`, `index-updating.md`, `scanning.md`, `embeddings.md`, `graph.md`, `headless-contract.md`, `sources/git.md`
+- Related skills: hiivmind-corpus-build (interactive), hiivmind-corpus-refresh-headless, hiivmind-corpus-enrich-headless, hiivmind-corpus-status-headless, hiivmind-corpus-migrate, hiivmind-corpus-init, hiivmind-corpus-add-source, hiivmind-corpus-enhance, hiivmind-corpus-refresh, hiivmind-corpus-navigate, hiivmind-corpus-graph, hiivmind-corpus-bridge, hiivmind-corpus-discover, hiivmind-corpus-register, hiivmind-corpus-status

--- a/skills/hiivmind-corpus-build/SKILL.md
+++ b/skills/hiivmind-corpus-build/SKILL.md
@@ -681,7 +681,9 @@ GUARD_PHASE_8():
    opt-in outcome — true if the user enabled embeddings, else false);
    `verify_on_build` / `verify_sample_size` (Phase 7c settings);
    `decided_at = now()`. Preserve any keys the user set by hand. This block lets
-   enhance/refresh/enrich-headless replay these decisions instead of re-asking.
+   enhance/refresh/enrich-headless replay these decisions instead of re-asking,
+   and lets `hiivmind-corpus-build-headless` reconstruct the whole index
+   non-interactively.
 
 ### Completion
 
@@ -739,6 +741,7 @@ Sources indexed: {source_count}
 
 - Migrate v1→v2 (headless): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-migrate/SKILL.md`
 - Headless status (pipelines): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-status-headless/SKILL.md`
+- Headless rebuild (pipelines): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-build-headless/SKILL.md`
 - Initialize corpus: `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-init/SKILL.md`
 - Add sources: `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-add-source/SKILL.md`
 - Enhance topics: `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-enhance/SKILL.md`

--- a/skills/hiivmind-corpus-discover/SKILL.md
+++ b/skills/hiivmind-corpus-discover/SKILL.md
@@ -382,6 +382,7 @@ Skip and note in output:
 
 - Migrate v1→v2 (headless): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-migrate/SKILL.md`
 - Headless status (pipelines): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-status-headless/SKILL.md`
+- Headless rebuild (pipelines): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-build-headless/SKILL.md`
 - **Navigate:** `skills/hiivmind-corpus-navigate/SKILL.md` - Query corpus documentation
 - **Register:** `skills/hiivmind-corpus-register/SKILL.md` - Add corpus to registry
 - **Status:** `skills/hiivmind-corpus-status/SKILL.md` - Check corpus health

--- a/skills/hiivmind-corpus-enhance/SKILL.md
+++ b/skills/hiivmind-corpus-enhance/SKILL.md
@@ -698,6 +698,7 @@ User: "The detailed actions sub-index"
 
 - Migrate v1→v2 (headless): `skills/hiivmind-corpus-migrate/SKILL.md`
 - Headless status (pipelines): `skills/hiivmind-corpus-status-headless/SKILL.md`
+- Headless rebuild (pipelines): `skills/hiivmind-corpus-build-headless/SKILL.md`
 - Add sources: `skills/hiivmind-corpus-add-source/SKILL.md`
 - Initialize corpus: `skills/hiivmind-corpus-init/SKILL.md`
 - Build index: `skills/hiivmind-corpus-build/SKILL.md`

--- a/skills/hiivmind-corpus-enrich-headless/SKILL.md
+++ b/skills/hiivmind-corpus-enrich-headless/SKILL.md
@@ -237,6 +237,7 @@ Write the file even on abort or zero-work runs.
 
 - Migrate v1→v2 (headless): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-migrate/SKILL.md`
 - Headless status (pipelines): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-status-headless/SKILL.md`
+- Headless rebuild (pipelines): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-build-headless/SKILL.md`
 - Headless refresh (runs before this): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-refresh-headless/SKILL.md`
 - Interactive refresh: `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-refresh/SKILL.md`
 - Build index: `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-build/SKILL.md`

--- a/skills/hiivmind-corpus-graph/SKILL.md
+++ b/skills/hiivmind-corpus-graph/SKILL.md
@@ -252,6 +252,7 @@ Add a typed relationship between two existing concepts. Supports explicit (args)
 
 - Migrate v1→v2 (headless): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-migrate/SKILL.md`
 - Headless status (pipelines): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-status-headless/SKILL.md`
+- Headless rebuild (pipelines): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-build-headless/SKILL.md`
 - `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-build/SKILL.md` — Generates graph.yaml during build
 - `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-navigate/SKILL.md` — Uses graph.yaml for enriched retrieval
 - `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-bridge/SKILL.md` — Cross-corpus concept bridges and aliases

--- a/skills/hiivmind-corpus-init/SKILL.md
+++ b/skills/hiivmind-corpus-init/SKILL.md
@@ -347,6 +347,7 @@ Done — do NOT invoke add-source.
 
 - Migrate v1→v2 (headless): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-migrate/SKILL.md`
 - Headless status (pipelines): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-status-headless/SKILL.md`
+- Headless rebuild (pipelines): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-build-headless/SKILL.md`
 - Add sources: `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-add-source/SKILL.md`
 - Build index: `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-build/SKILL.md`
 - Refresh sources: `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-refresh/SKILL.md`

--- a/skills/hiivmind-corpus-migrate/SKILL.md
+++ b/skills/hiivmind-corpus-migrate/SKILL.md
@@ -158,4 +158,4 @@ Write the result file even on ABORT (with `error` populated and
 ## Reference
 
 - Patterns: `config-parsing.md`, `index-format-v2.md`, `index-rendering.md`, `headless-contract.md`, `sources/git.md`
-- Related skills: hiivmind-corpus-build, hiivmind-corpus-refresh, hiivmind-corpus-refresh-headless, hiivmind-corpus-enrich-headless, hiivmind-corpus-enhance, hiivmind-corpus-status, hiivmind-corpus-status-headless, hiivmind-corpus-navigate, hiivmind-corpus-graph, hiivmind-corpus-init, hiivmind-corpus-add-source, hiivmind-corpus-discover, hiivmind-corpus-register, hiivmind-corpus-bridge
+- Related skills: hiivmind-corpus-build, hiivmind-corpus-refresh, hiivmind-corpus-build-headless, hiivmind-corpus-refresh-headless, hiivmind-corpus-enrich-headless, hiivmind-corpus-enhance, hiivmind-corpus-status, hiivmind-corpus-status-headless, hiivmind-corpus-navigate, hiivmind-corpus-graph, hiivmind-corpus-init, hiivmind-corpus-add-source, hiivmind-corpus-discover, hiivmind-corpus-register, hiivmind-corpus-bridge

--- a/skills/hiivmind-corpus-navigate/SKILL.md
+++ b/skills/hiivmind-corpus-navigate/SKILL.md
@@ -640,6 +640,7 @@ The documentation may have moved. Try:
 
 - Migrate v1→v2 (headless): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-migrate/SKILL.md`
 - Headless status (pipelines): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-status-headless/SKILL.md`
+- Headless rebuild (pipelines): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-build-headless/SKILL.md`
 - **Register:** `hiivmind-corpus-register` - Add corpora to the registry
 - **Status:** `hiivmind-corpus-status` - Check corpus health
 - **Discover:** `hiivmind-corpus-discover` - Find available corpora

--- a/skills/hiivmind-corpus-refresh-headless/SKILL.md
+++ b/skills/hiivmind-corpus-refresh-headless/SKILL.md
@@ -269,6 +269,7 @@ until enrich-headless or a rebuild runs.
 
 - Migrate v1→v2 (headless): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-migrate/SKILL.md`
 - Headless status (pipelines): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-status-headless/SKILL.md`
+- Headless rebuild (pipelines): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-build-headless/SKILL.md`
 - Enrichment (run after refresh): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-enrich-headless/SKILL.md`
 - Interactive refresh: `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-refresh/SKILL.md`
 - Build index: `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-build/SKILL.md`

--- a/skills/hiivmind-corpus-refresh/SKILL.md
+++ b/skills/hiivmind-corpus-refresh/SKILL.md
@@ -349,6 +349,7 @@ GUARD_REFRESH_VERIFICATION():
 
 - Migrate v1→v2 (headless): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-migrate/SKILL.md`
 - Headless status (pipelines): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-status-headless/SKILL.md`
+- Headless rebuild (pipelines): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-build-headless/SKILL.md`
 - Initialize corpus: `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-init/SKILL.md`
 - Add sources: `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-add-source/SKILL.md`
 - Build index: `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-build/SKILL.md`

--- a/skills/hiivmind-corpus-register/SKILL.md
+++ b/skills/hiivmind-corpus-register/SKILL.md
@@ -271,6 +271,7 @@ corpora:
 
 - Migrate v1→v2 (headless): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-migrate/SKILL.md`
 - Headless status (pipelines): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-status-headless/SKILL.md`
+- Headless rebuild (pipelines): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-build-headless/SKILL.md`
 - **Navigate:** `hiivmind-corpus-navigate` - Query registered corpora
 - **Status:** `hiivmind-corpus-status` - Check corpus health
 - **Discover:** `hiivmind-corpus-discover` - Find available corpora

--- a/skills/hiivmind-corpus-status-headless/SKILL.md
+++ b/skills/hiivmind-corpus-status-headless/SKILL.md
@@ -62,4 +62,4 @@ Ensure `status-result.yaml` is in the corpus `.gitignore` (append if missing).
 ## Reference
 
 - Patterns: `status.md`, `freshness.md`, `config-parsing.md`, `embeddings.md`, `headless-contract.md`
-- Related skills: hiivmind-corpus-status (interactive), hiivmind-corpus-refresh-headless, hiivmind-corpus-enrich-headless, hiivmind-corpus-migrate, hiivmind-corpus-discover, hiivmind-corpus-navigate, hiivmind-corpus-build, hiivmind-corpus-refresh, hiivmind-corpus-enhance, hiivmind-corpus-graph, hiivmind-corpus-bridge, hiivmind-corpus-init, hiivmind-corpus-add-source, hiivmind-corpus-register
+- Related skills: hiivmind-corpus-status (interactive), hiivmind-corpus-build-headless, hiivmind-corpus-refresh-headless, hiivmind-corpus-enrich-headless, hiivmind-corpus-migrate, hiivmind-corpus-discover, hiivmind-corpus-navigate, hiivmind-corpus-build, hiivmind-corpus-refresh, hiivmind-corpus-enhance, hiivmind-corpus-graph, hiivmind-corpus-bridge, hiivmind-corpus-init, hiivmind-corpus-add-source, hiivmind-corpus-register

--- a/skills/hiivmind-corpus-status/SKILL.md
+++ b/skills/hiivmind-corpus-status/SKILL.md
@@ -355,6 +355,7 @@ Documentation may be outdated.
 
 - Migrate v1→v2 (headless): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-migrate/SKILL.md`
 - Headless status (pipelines): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-status-headless/SKILL.md`
+- Headless rebuild (pipelines): `${CLAUDE_PLUGIN_ROOT}/skills/hiivmind-corpus-build-headless/SKILL.md`
 - **Navigate:** `hiivmind-corpus-navigate` - Query corpus documentation
 - **Register:** `hiivmind-corpus-register` - Add new corpora
 - **Refresh:** `hiivmind-corpus-refresh` - Update stale corpora


### PR DESCRIPTION
Adds the headless build skill — the replay counterpart to Wave 4's decision capture. The interactive build records every Phase 3/4 answer in `config.build`; this skill replays that block to reconstruct the whole index with no prompts, closing backlog 06's stretch goal.

## What it does
`hiivmind-corpus-build-headless` mirrors the interactive build's pipeline (prepare → scan → segment → index → graph → embeddings → verify → save), but:
- **Reads `config.build`** for segmentation, organization, skip_sections, embeddings opt-in, and verify prefs instead of asking.
- **ABORTs when there is no `config.build` block** — it never invents organization; the deliberate gate is that decisions must have been captured by an interactive build first.
- **Non-interactive throughout:** auto-accepts clustered graph concepts, never downloads an embedding model (`no-model` → skip), reports verification drift without prompting to regenerate.
- Writes **`build-result.yaml`** (`kind: build`) and renders via `render-index.sh`.

## Contract
New `build` kind in the headless contract + `validate_result.py` (entries, sources[], strategy, sections, graph, embeddings, verification). 2 new tests. **156 passed.**

## Alignment
CLAUDE.md (tree, naming, skills list, cross-cutting rows, dependency chain), gateway command, `config-parsing.md` (§ build: block now points to build-headless instead of calling it "future"), build Phase 8 pointer, and all 15 existing skills' Related Skills sections.

Depends on Wave 4 (merged, PR #51) for the `config.build` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)