### PR TITLE
Support resolved corpus context in status Skills

### DIFF
--- a/lib/corpus/scripts/tests/test_skill_runtime_contracts.py
+++ b/lib/corpus/scripts/tests/test_skill_runtime_contracts.py
@@ -1,0 +1,24 @@
+"""Instruction-contract tests for resolved corpus status execution."""
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[4]
+STATUS_SKILL = ROOT / "skills/hiivmind-corpus-status/SKILL.md"
+HEADLESS_STATUS_SKILL = ROOT / "skills/hiivmind-corpus-status-headless/SKILL.md"
+
+
+def test_interactive_status_checks_resolved_context_before_registry():
+    text = STATUS_SKILL.read_text(encoding="utf-8")
+    resolved = text.index("Resolved corpus context")
+    registry = text.index("Consumer project registry")
+    assert resolved < registry
+    assert 'workspace_role: "corpus-root"' in text
+    assert "Read `config.yaml` from the logical workspace root" in text
+
+
+def test_headless_status_declares_real_effects():
+    text = HEADLESS_STATUS_SKILL.read_text(encoding="utf-8")
+    assert "writes the configured result artifact" in text
+    assert "git ls-remote" in text
+    assert "Never modifies corpus source-of-truth files" in text
+    assert "Read-only freshness snapshot" not in text

--- a/skills/hiivmind-corpus-status-headless/SKILL.md
+++ b/skills/hiivmind-corpus-status-headless/SKILL.md
@@ -9,9 +9,12 @@ description: >
 
 # Corpus Status (Headless)
 
-Read-only freshness snapshot of ONE corpus, written as a machine-readable
-result file. Designed as a cheap pre-check before a full refresh (ls-remote,
-not clone) and for nightly status sweeps across corpora.
+Freshness snapshot of ONE corpus, written as a machine-readable result file.
+Never modifies corpus source-of-truth files. It writes the configured result artifact.
+It may append its path to `.gitignore`, runs bounded validation and process
+commands, and may contact configured upstream git remotes via `git ls-remote`.
+Designed as a cheap pre-check before a full refresh (no clone) and for nightly
+status sweeps across corpora.
 
 **Inputs:**
 - `corpus_path` (required)
@@ -34,7 +37,8 @@ not clone) and for nightly status sweeps across corpora.
    to get `embedded_at`, then count entries whose `last_indexed` postdates it
    (see `patterns/embeddings.md` § Embedding Lag). No lance dir → `null`.
 5. **Write result** (contract below), echo a one-line summary. Never modify
-   the corpus. Write the result file even on ABORT, with `errors` populated.
+   corpus source-of-truth files. Write the result file even on ABORT, with
+   `errors` populated.
 
 ## Output Contract
 

--- a/skills/hiivmind-corpus-status/SKILL.md
+++ b/skills/hiivmind-corpus-status/SKILL.md
@@ -20,6 +20,20 @@ index status, source availability, and cache state.
 
 ## Workflow
 
+### Resolved corpus context
+
+When the trusted runtime input describes `kind: corpus` and
+`workspace_role: "corpus-root"`, inspect that one corpus.
+Read `config.yaml` from the logical workspace root. Then inspect its index and
+sources. Do not search for
+`.hiivmind/corpus/registry.yaml`; the application has already resolved the
+corpus identity and workspace.
+
+### Consumer project registry
+
+When resolved corpus context is absent, discover registered corpora from
+`.hiivmind/corpus/registry.yaml` and follow the multi-corpus workflow below.
+
 ### Phase 1: Load Registry
 
 Read `.hiivmind/corpus/registry.yaml`:


### PR DESCRIPTION
## What changed

- Updates the interactive status Skill to recognize trusted resolved-corpus context and inspect that corpus directly.
- Preserves registry-based discovery for consumer projects.
- Clarifies the headless status Skill's result artifact, bounded command behavior, Git remote access, and permitted `.gitignore` update.
- Adds contract regression coverage.

## Why

The canonical status Skills previously assumed consumer-project registry discovery. A governed Operations agent already resolves the corpus identity and workspace, so repeating registry discovery fails in that runtime.

## Impact

The same reusable status Skills now work both from ordinary consumer projects and from a trusted corpus-specific Operations gateway without embedding client-specific logic in the Skills.

## Validation

- 158 tests passed
- 1 skipped
- 30 model tests deselected
- independent final review found no blocking issues

## Companion work

- hiivmind/agent-kernel#3 — governed operational Skill runtime
- hiivmind/agno-oracle-demo#18 — AgentOS consumer integration
